### PR TITLE
Don't load print.css with media='screen'

### DIFF
--- a/flask_apispec/templates/swagger-ui.html
+++ b/flask_apispec/templates/swagger-ui.html
@@ -9,7 +9,8 @@
   <link href="{{ url_for('flask-apispec.static', filename='css/typography.css') }}" media='screen' rel="stylesheet" type="text/css"/>
   <link href="{{ url_for('flask-apispec.static', filename='css/reset.css') }}" media='screen' rel="stylesheet" type="text/css"/>
   <link href="{{ url_for('flask-apispec.static', filename='css/screen.css') }}" media='screen' rel="stylesheet" type="text/css"/>
-  <link href="{{ url_for('flask-apispec.static', filename='css/print.css') }}" media='screen' rel="stylesheet" type="text/css"/>
+  <link href="{{ url_for('flask-apispec.static', filename='css/reset.css') }}" media='print' rel="stylesheet" type="text/css"/>
+  <link href="{{ url_for('flask-apispec.static', filename='css/print.css') }}" media='print' rel="stylesheet" type="text/css"/>
 
   <script src="{{ url_for('flask-apispec.static', filename='lib/jquery-1.8.0.min.js') }}" type="text/javascript"></script>
   <script src="{{ url_for('flask-apispec.static', filename='lib/jquery.slideto.min.js') }}" type="text/javascript"></script>


### PR DESCRIPTION
This updates the `<link>` tags to match the current version of swagger-ui. Without the fix, toggling content is completely broken.