### PR TITLE
Update swagger-ui.html

### DIFF
--- a/flask_apispec/templates/swagger-ui.html
+++ b/flask_apispec/templates/swagger-ui.html
@@ -3,8 +3,8 @@
 <head>
   <meta charset="UTF-8">
   <title>Swagger UI</title>
-  <link rel="icon" type="image/png" href="images/favicon-32x32.png" sizes="32x32" />
-  <link rel="icon" type="image/png" href="images/favicon-16x16.png" sizes="16x16" />
+  <link rel="icon" type="image/png" href="{{ url_for('flask-apispec.static', filename='images/favicon-32x32.png') }}" sizes="32x32" />
+  <link rel="icon" type="image/png" href="{{ url_for('flask-apispec.static', filename='images/favicon-16x16.png') }}" sizes="16x16" />
 
   <link href="{{ url_for('flask-apispec.static', filename='css/typography.css') }}" media='screen' rel="stylesheet" type="text/css"/>
   <link href="{{ url_for('flask-apispec.static', filename='css/reset.css') }}" media='screen' rel="stylesheet" type="text/css"/>


### PR DESCRIPTION
Fixed - favicon HREFs now use the static path.