### PR TITLE
Fix example

### DIFF
--- a/examples/petstore.py
+++ b/examples/petstore.py
@@ -95,4 +95,7 @@ class CatResource(MethodResource):
         return Pet('calici', 'cat')
 
 app.add_url_rule('/cat/<pet_id>', view_func=CatResource.as_view('CatResource'))
-docs.register(CatResource)
+docs.register(CatResource, endpoint='CatResource')
+
+if __name__ == '__main__':
+    app.run(debug=True)


### PR DESCRIPTION
There is a `KeyError` while running `petstore.py`:

```
Traceback (most recent call last):
  File "petstore.py", line 98, in <module>
    docs.register(CatResource)
  File "/Users/abnerchen/Projects/flask/flask-apispec/examples/venv/lib/python3.5/site-packages/flask_apispec/extension.py", line 74, in register
    paths = self.resource_converter.convert(target, endpoint, blueprint)
  File "/Users/abnerchen/Projects/flask/flask-apispec/examples/venv/lib/python3.5/site-packages/flask_apispec/apidoc.py", line 24, in convert
    rules = self.app.url_map._rules_by_endpoint[endpoint]
KeyError: 'catresource'
```

And the content of `self.app.url_map._rules_by_endpoint` is:

```
{
    'flask-apispec.swagger-ui': [<Rule '/swagger-ui/' (OPTIONS, HEAD, GET) -> flask-apispec.swagger-ui>], 
    'CatResource': [<Rule '/cat/<pet_id>' (PUT, HEAD, OPTIONS, GET) -> CatResource>], 
    'flask-apispec.swagger-json': [<Rule '/swagger/' (OPTIONS, HEAD, GET) -> flask-apispec.swagger-json>], 
    'get_pet': [<Rule '/pets/<pet_id>' (OPTIONS, HEAD, GET) -> get_pet>], 
    'static': [<Rule '/static/<filename>' (OPTIONS, HEAD, GET) -> static>], 
    'flask-apispec.static': [<Rule '/flask-apispec/static/<filename>' (OPTIONS, HEAD, GET) -> flask-apispec.static>]
}
```

So I added the endpoint value in registration.

And I also added `app.run` to bring up the server.