### PR TITLE
Add support for view class constructor arguments.

### DIFF
--- a/flask_apispec/annotations.py
+++ b/flask_apispec/annotations.py
@@ -26,6 +26,7 @@ def use_kwargs(args, locations=None, inherit=None, apply=None, **kwargs):
     :param apply: Parse request with specified args
     """
     kwargs.update({'locations': locations})
+
     def wrapper(func):
         options = {
             'args': args,

--- a/flask_apispec/apidoc.py
+++ b/flask_apispec/apidoc.py
@@ -17,16 +17,16 @@ class Converter(object):
     def __init__(self, app):
         self.app = app
 
-    def convert(self, target, endpoint=None, blueprint=None):
+    def convert(self, target, endpoint=None, blueprint=None, **kwargs):
         endpoint = endpoint or target.__name__.lower()
         if blueprint:
             endpoint = '{}.{}'.format(blueprint, endpoint)
         rules = self.app.url_map._rules_by_endpoint[endpoint]
-        return [self.get_path(rule, target) for rule in rules]
+        return [self.get_path(rule, target, **kwargs) for rule in rules]
 
-    def get_path(self, rule, target):
+    def get_path(self, rule, target, **kwargs):
         operations = self.get_operations(rule, target)
-        parent = self.get_parent(target)
+        parent = self.get_parent(target, **kwargs)
         return {
             'view': target,
             'path': rule_to_path(rule),
@@ -89,5 +89,5 @@ class ResourceConverter(Converter):
             if hasattr(resource, method.lower())
         }
 
-    def get_parent(self, resource):
-        return resolve_instance(resource)
+    def get_parent(self, resource, **kwargs):
+        return resolve_instance(resource, **kwargs)

--- a/flask_apispec/extension.py
+++ b/flask_apispec/extension.py
@@ -67,11 +67,21 @@ class FlaskApiSpec(object):
     def swagger_ui(self):
         return flask.render_template('swagger-ui.html')
 
-    def register(self, target, endpoint=None, blueprint=None):
+    def register(self, target, endpoint=None, blueprint=None, **kwargs):
+        """Register a view.
+
+        :param target: view function or view class.
+        :param endpoint: (optional) endpoint name.
+        :param blueprint: (optional) blueprint name.
+        :param tuple resource_class_args: (optional) args to be forwarded to the
+            constructor of the resource.
+        :param dict resource_class_kwargs: (optional) kwargs to be forwarded to
+            the constructor of the resource.
+        """
         if isinstance(target, types.FunctionType):
             paths = self.view_converter.convert(target, endpoint, blueprint)
         elif isinstance(target, ResourceMeta):
-            paths = self.resource_converter.convert(target, endpoint, blueprint)
+            paths = self.resource_converter.convert(target, endpoint, blueprint, **kwargs)
         else:
             raise TypeError()
         for path in paths:

--- a/flask_apispec/extension.py
+++ b/flask_apispec/extension.py
@@ -74,9 +74,9 @@ class FlaskApiSpec(object):
         :param endpoint: (optional) endpoint name.
         :param blueprint: (optional) blueprint name.
         :param tuple resource_class_args: (optional) args to be forwarded to the
-            constructor of the resource.
+            view class constructor.
         :param dict resource_class_kwargs: (optional) kwargs to be forwarded to
-            the constructor of the resource.
+            the view class constructor.
         """
         if isinstance(target, types.FunctionType):
             paths = self.view_converter.convert(target, endpoint, blueprint)

--- a/flask_apispec/extension.py
+++ b/flask_apispec/extension.py
@@ -67,7 +67,8 @@ class FlaskApiSpec(object):
     def swagger_ui(self):
         return flask.render_template('swagger-ui.html')
 
-    def register(self, target, endpoint=None, blueprint=None, **kwargs):
+    def register(self, target, endpoint=None, blueprint=None,
+                 resource_class_args=None, resource_class_kwargs=None):
         """Register a view.
 
         :param target: view function or view class.
@@ -81,7 +82,13 @@ class FlaskApiSpec(object):
         if isinstance(target, types.FunctionType):
             paths = self.view_converter.convert(target, endpoint, blueprint)
         elif isinstance(target, ResourceMeta):
-            paths = self.resource_converter.convert(target, endpoint, blueprint, **kwargs)
+            paths = self.resource_converter.convert(
+                target,
+                endpoint,
+                blueprint,
+                resource_class_args=resource_class_args,
+                resource_class_kwargs=resource_class_kwargs,
+            )
         else:
             raise TypeError()
         for path in paths:

--- a/flask_apispec/paths.py
+++ b/flask_apispec/paths.py
@@ -8,6 +8,7 @@ PATH_RE = re.compile(r'<(?:[^:<>]+:)?([^<>]+)>')
 def rule_to_path(rule):
     return PATH_RE.sub(r'{\1}', rule.rule)
 
+
 CONVERTER_MAPPING = {
     werkzeug.routing.UnicodeConverter: ('string', None),
     werkzeug.routing.IntegerConverter: ('integer', 'int32'),

--- a/flask_apispec/utils.py
+++ b/flask_apispec/utils.py
@@ -4,9 +4,11 @@ import functools
 
 import six
 
-def resolve_instance(schema):
+def resolve_instance(schema, **kwargs):
+    resource_class_args = kwargs.pop('resource_class_args', ())
+    resource_class_kwargs = kwargs.pop('resource_class_kwargs', {})
     if isinstance(schema, type):
-        return schema()
+        return schema(*resource_class_args, **resource_class_kwargs)
     return schema
 
 class Ref(object):

--- a/flask_apispec/utils.py
+++ b/flask_apispec/utils.py
@@ -5,8 +5,9 @@ import functools
 import six
 
 def resolve_instance(schema, **kwargs):
-    resource_class_args = kwargs.pop('resource_class_args', ())
-    resource_class_kwargs = kwargs.pop('resource_class_kwargs', {})
+    kwargs = kwargs or {}
+    resource_class_args = kwargs.get('resource_class_args') or ()
+    resource_class_kwargs = kwargs.get('resource_class_kwargs') or {}
     if isinstance(schema, type):
         return schema(*resource_class_args, **resource_class_kwargs)
     return schema

--- a/tests/test_extension.py
+++ b/tests/test_extension.py
@@ -29,6 +29,22 @@ class TestExtension:
         docs.register(BandResource, endpoint='band')
         assert '/bands/{band_id}/' in docs.spec._paths
 
+    def test_register_resource_with_constructor_args(self, app, docs):
+        @doc(tags=['band'])
+        class BandResource(MethodResource):
+            def __init__(self, arg_one, arg_two):
+                pass
+
+            def get(self, **kwargs):
+                return 'kraftwerk'
+
+        app.add_url_rule('/bands/<band_id>/',
+                         view_func=BandResource.as_view('band', True, arg_two=False))
+        docs.register(BandResource, endpoint='band',
+                      resource_class_args=(True, ),
+                      resource_class_kwargs={'arg_two': True})
+        assert '/bands/{band_id}/' in docs.spec._paths
+
     def test_serve_swagger(self, app, docs, client):
         res = client.get('/swagger/')
         assert res.json == docs.spec.to_dict()


### PR DESCRIPTION
Currently, is not possible to register view classes that require constructor arguments.

This PR tries to solve this issue, adding two optional arguments to the `register` method:
- `resource_class_args`: args to be forwarded to the view class constructor.
- `resource_class_kwargs`: kwargs to be forwared to the view class constructor.