### PR TITLE
Latest invoke releases require context as task argument.

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,5 +1,5 @@
 # Task running
-invoke
+invoke>=0.13.0
 
 # Testing
 flake8

--- a/tasks.py
+++ b/tasks.py
@@ -3,22 +3,22 @@
 from invoke import task, run
 
 @task
-def clean():
+def clean(ctx):
     run('rm -rf dist')
     run('rm -rf build')
     run('rm -rf flask_apispec.egg-info')
 
 @task
-def install():
+def install(ctx):
     run('npm install')
     run('rm -rf flask_apispec/static')
     run('cp -r node_modules/swagger-ui/dist flask_apispec/static')
 
 @task
-def publish(test=False):
+def publish(ctx, test=False):
     """Publish to the cheeseshop."""
-    clean()
-    install()
+    clean(ctx)
+    install(ctx)
     if test:
         run('python setup.py register -r test sdist bdist_wheel', echo=True)
         run('twine upload dist/* -r test', echo=True)


### PR DESCRIPTION
invoke >= 0.13.0 requires to explicitly pass the context to the defined tasks:
```python
@task
def clean(ctx):
   run('rm -rf dist')
    ...
```