### PR TITLE
Support to query params and header params

### DIFF
--- a/flask_apispec/paths.py
+++ b/flask_apispec/paths.py
@@ -18,11 +18,16 @@ CONVERTER_MAPPING = {
 DEFAULT_TYPE = ('string', None)
 
 def rule_to_params(rule, overrides=None):
-    overrides = overrides or {}
-    return [
+    overrides = (overrides or {})
+    result = [
         argument_to_param(argument, rule, overrides.get(argument, {}))
         for argument in rule.arguments
     ]
+    for key in overrides.keys():
+        if overrides[key].get('in') in ('header', 'query'):
+            overrides[key]['name'] = overrides[key].get('name', key)
+            result.append(overrides[key])
+    return result
 
 def argument_to_param(argument, rule, override=None):
     param = {

--- a/tests/test_paths.py
+++ b/tests/test_paths.py
@@ -8,8 +8,8 @@ def make_rule(app, path, **kwargs):
         pass
     return app.url_map._rules_by_endpoint['view'][0]
 
-def make_param(**kwargs):
-    ret = {'in': 'path', 'required': True}
+def make_param(in_location='path', **kwargs):
+    ret = {'in': in_location, 'required': True}
     ret.update(kwargs)
     return ret
 
@@ -55,4 +55,12 @@ class TestPathParams:
         overrides = {'band_id': {'description': 'the band id'}}
         params = rule_to_params(rule, overrides=overrides)
         expected = make_param(type='string', name='band_id', description='the band id')
+        assert params[0] == expected
+ 
+    def test_params_override_header(self, app):
+        rule = make_rule(app, '/some_path/')
+        overrides = {'Authorization': {'type': 'string', 'description': 'The authorization token', 'in': 'header', 'required': True}}
+        params = rule_to_params(rule, overrides=overrides)
+        expected = make_param(type='string', name='Authorization', in_location='header', description='The authorization token',
+                              required=True)
         assert params[0] == expected


### PR DESCRIPTION
Simple way to add query params and header params

I need Authorization header param (OAUTH2).

Like Authorization: Bearer <bearer_token_value>

![image](https://cloud.githubusercontent.com/assets/10155053/22317962/30ad4e9a-e35e-11e6-9418-bfe33482bb66.png)
