### PR TITLE
Defer registering views until after init_app

### DIFF
--- a/flask_apispec/extension.py
+++ b/flask_apispec/extension.py
@@ -52,7 +52,7 @@ class FlaskApiSpec(object):
         self.resource_converter = ResourceConverter(self.app)
         self.spec = self.app.config.get('APISPEC_SPEC') or \
                     make_apispec(self.app.config.get('APISPEC_TITLE', 'flask-apispec'),
-                                 self.app.config.get('APISPEC_VERSION', 'flask-apispec'))
+                                 self.app.config.get('APISPEC_VERSION', 'v1'))
         self.add_routes()
 
         for deferred in self._deferred:

--- a/flask_apispec/extension.py
+++ b/flask_apispec/extension.py
@@ -36,6 +36,7 @@ class FlaskApiSpec(object):
     :param Flask app: App associated with API documentation
     :param APISpec spec: apispec specification associated with API documentation
     """
+
     def __init__(self, app=None):
         self._deferred = []
         self.app = app
@@ -50,7 +51,9 @@ class FlaskApiSpec(object):
         self.app = app
         self.view_converter = ViewConverter(self.app)
         self.resource_converter = ResourceConverter(self.app)
-        self.spec = self.app.config.get('APISPEC_SPEC') or make_apispec()
+        self.spec = self.app.config.get('APISPEC_SPEC') or \
+                    make_apispec(self.app.config.get('APISPEC_TITLE', 'flask-apispec'),
+                                 self.app.config.get('APISPEC_VERSION', 'flask-apispec'))
         self.add_routes()
 
         @app.before_first_request
@@ -128,9 +131,10 @@ class FlaskApiSpec(object):
         for path in paths:
             self.spec.add_path(**path)
 
-def make_apispec():
+
+def make_apispec(title='flask-apispec', version='v1'):
     return APISpec(
-        title='flask-apispec',
-        version='v1',
+        title=title,
+        version=version,
         plugins=['apispec.ext.marshmallow'],
     )

--- a/tests/test_extension.py
+++ b/tests/test_extension.py
@@ -28,7 +28,6 @@ class TestExtension:
         app.register_blueprint(blueprint)
         docs.init_app(app)
 
-        print(docs.spec.to_dict())
         assert '/bands/{band_id}/' in docs.spec._paths
 
     def test_register_function(self, app, docs):
@@ -81,3 +80,13 @@ class TestExtension:
         app.config['APISPEC_SWAGGER_UI_URL'] = '/swagger-ui.html'
         FlaskApiSpec(app)
         client.get('/swagger-ui.html')
+
+    def test_apispec_config(self, app):
+        app.config['APISPEC_TITLE'] = 'test-extension'
+        app.config['APISPEC_VERSION'] = '2.1'
+        docs = FlaskApiSpec(app)
+
+        assert docs.spec.info == {
+            'title': 'test-extension',
+            'version': '2.1',
+        }


### PR DESCRIPTION
This allows for better flask factory pattern support, with deferred loading of blueprints until after the app is created

I also added APISPEC_TITLE and APISPEC_VERSION configuration options from Flask config