### PR TITLE
Compatibility with apispec 0.20

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,15 @@
+coverage:
+
+  status:
+    project:                   # measuring the overall project coverage
+      default:                 # context, you can create multiple ones with custom titles
+        enabled: yes           # must be yes|true to enable this status
+        threshold: 0.5         # allowed to drop X% and still result in a "success" commit status
+
+    patch:                     # pull requests only: this commit status will measure the
+                               # entire pull requests Coverage Diff. Checking if the lines
+                               # adjusted are covered at least X%.
+      default:
+        enabled: yes           # must be yes|true to enable this status
+        threshold: 0.5         # allowed to drop X% and still result in a "success" commit status
+

--- a/flask_apispec/annotations.py
+++ b/flask_apispec/annotations.py
@@ -26,6 +26,7 @@ def use_kwargs(args, locations=None, inherit=None, apply=None, **kwargs):
     :param apply: Parse request with specified args
     """
     kwargs.update({'locations': locations})
+
     def wrapper(func):
         options = {
             'args': args,

--- a/flask_apispec/apidoc.py
+++ b/flask_apispec/apidoc.py
@@ -3,6 +3,9 @@
 import copy
 
 import six
+from pkg_resources import parse_version
+
+import apispec
 from apispec.core import VALID_METHODS
 from apispec.ext.marshmallow import swagger
 
@@ -65,9 +68,10 @@ class Converter(object):
         locations = options.pop('locations', None)
         if locations:
             options['default_in'] = locations[0]
+        if parse_version(apispec.__version__) < parse_version('0.20.0'):
+            options['dump'] = False
         return converter(
             args.get('args', {}),
-            dump=False,
             **options
         ) + rule_to_params(rule, docs.get('params'))
 

--- a/flask_apispec/paths.py
+++ b/flask_apispec/paths.py
@@ -5,8 +5,10 @@ import re
 import werkzeug.routing
 
 PATH_RE = re.compile(r'<(?:[^:<>]+:)?([^<>]+)>')
+
 def rule_to_path(rule):
     return PATH_RE.sub(r'{\1}', rule.rule)
+
 
 CONVERTER_MAPPING = {
     werkzeug.routing.UnicodeConverter: ('string', None),


### PR DESCRIPTION
This fixes issues #41 , allowing compatibility with apispec 0.20.0 as well as earlier versions (tested with apispec v0.20 in CI and v0.19 manually).

Also a few minor style changes to keep flake8 happy..