### PR TITLE
Bump support versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,9 @@ sudo: false
 
 python:
   - "2.7"
-  - "3.3"
   - "3.4"
   - "3.5"
+  - "3.6"
   - "pypy"
 
 before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,12 @@ language: python
 
 sudo: false
 
+env:
+  # Lowest supported version
+  - APISPEC_VERSION="==0.17.0"
+  # Latest release
+  - APISPEC_VERSION=""
+
 python:
   - "2.7"
   - "3.4"
@@ -15,6 +21,7 @@ before_install:
 install:
   - travis_retry pip install -U .
   - travis_retry pip install -U -r dev-requirements.txt
+  - travis_retry pip install -U apispec"$APISPEC_VERSION"
 
 before_script:
   - flake8 flask_apispec

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,6 +9,10 @@ Features:
 * Add `resource_class_args` and `resource_class_kwargs` to `FlaskApiSpec.register` for passing constructor arguments to `MethodResource` classes. Thanks @elatomo.
 * Add `FlaskApiSpec.init_app` method to support app factories (#21). Thanks @lafrech for the suggestion and thanks @dases for the PR.
 
+Other changes:
+
+- Test against Python 3.6. Prop support for Python 3.3.
+
 0.3.2 (2015-12-06)
 ++++++++++++++++++
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,7 +11,8 @@ Features:
 
 Other changes:
 
-- Test against Python 3.6. Prop support for Python 3.3.
+- Test against Python 3.6. Drop support for Python 3.3.
+- Support apispec>=0.17.0.
 
 0.3.2 (2015-12-06)
 ++++++++++++++++++

--- a/setup.py
+++ b/setup.py
@@ -56,9 +56,9 @@ setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.3',
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
     ],
     test_suite='tests'
 )

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ REQUIRES = [
     'flask>=0.10.1',
     'marshmallow>=2.0',
     'webargs>=0.18.0',
-    'apispec>=0.4.1',
+    'apispec>=0.17.0',
 ]
 
 def find_version(fname):

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist=py27,py33,py34,py35,pypy
+envlist=py27,py34,py35,py36,pypy
 [testenv]
 deps=
     -rdev-requirements.txt


### PR DESCRIPTION
- Add support for Python 3.6
- Drop support for Python 3.3
- Support apispec>=0.17.0

NOTE: Tests are expected to fail due to incompatibilities with apispec 0.20.0. This will be fixed by #45