### PR TITLE
Register existing endpoints, plus fixup empty parameters

### DIFF
--- a/flask_apispec/apidoc.py
+++ b/flask_apispec/apidoc.py
@@ -70,10 +70,14 @@ class Converter(object):
             options['default_in'] = locations[0]
         if parse_version(apispec.__version__) < parse_version('0.20.0'):
             options['dump'] = False
-        return converter(
+
+        rule_params = rule_to_params(rule, docs.get('params')) or []
+        extra_params = converter(
             args.get('args', {}),
             **options
-        ) + rule_to_params(rule, docs.get('params'))
+        ) if args else []
+
+        return extra_params + rule_params
 
     def get_responses(self, view, parent=None):
         annotation = resolve_annotations(view, 'schemas', parent)

--- a/flask_apispec/extension.py
+++ b/flask_apispec/extension.py
@@ -53,7 +53,10 @@ class FlaskApiSpec(object):
         self.spec = self.app.config.get('APISPEC_SPEC') or \
                     make_apispec(self.app.config.get('APISPEC_TITLE', 'flask-apispec'),
                                  self.app.config.get('APISPEC_VERSION', 'v1'))
-        self.add_routes()
+
+        self.register_existing_endpoints()
+
+        self.add_swagger_routes()
 
         for deferred in self._deferred:
             deferred()
@@ -64,7 +67,7 @@ class FlaskApiSpec(object):
         if self.app:
             bound()
 
-    def add_routes(self):
+    def add_swagger_routes(self):
         blueprint = flask.Blueprint(
             'flask-apispec',
             __name__,
@@ -88,6 +91,19 @@ class FlaskApiSpec(object):
 
     def swagger_ui(self):
         return flask.render_template('swagger-ui.html')
+
+    def register_existing_endpoints(self):
+        for name, rule in self.app.view_functions.items():
+            if name == 'static':
+                # For some reason, the default Flask `static` function breaks
+                continue
+
+            try:
+                blueprint_name, _ = name.split('.')
+            except ValueError:
+                blueprint_name = None
+            finally:
+                self.register(rule, blueprint=blueprint_name)
 
     def register(self, target, endpoint=None, blueprint=None,
                  resource_class_args=None, resource_class_kwargs=None):

--- a/flask_apispec/extension.py
+++ b/flask_apispec/extension.py
@@ -59,8 +59,6 @@ class FlaskApiSpec(object):
         for deferred in self._deferred:
             deferred()
 
-        self.register_existing_resources()
-
     def _defer(self, callable, *args, **kwargs):
         bound = functools.partial(callable, *args, **kwargs)
         self._deferred.append(bound)

--- a/flask_apispec/extension.py
+++ b/flask_apispec/extension.py
@@ -54,8 +54,7 @@ class FlaskApiSpec(object):
                     make_apispec(self.app.config.get('APISPEC_TITLE', 'flask-apispec'),
                                  self.app.config.get('APISPEC_VERSION', 'v1'))
 
-        self.register_existing_endpoints()
-
+        self.register_existing_resources()
         self.add_swagger_routes()
 
         for deferred in self._deferred:
@@ -92,18 +91,17 @@ class FlaskApiSpec(object):
     def swagger_ui(self):
         return flask.render_template('swagger-ui.html')
 
-    def register_existing_endpoints(self):
+    def register_existing_resources(self):
         for name, rule in self.app.view_functions.items():
-            if name == 'static':
-                # For some reason, the default Flask `static` function breaks
-                continue
-
             try:
                 blueprint_name, _ = name.split('.')
             except ValueError:
                 blueprint_name = None
-            finally:
+
+            try:
                 self.register(rule, blueprint=blueprint_name)
+            except TypeError:
+                pass
 
     def register(self, target, endpoint=None, blueprint=None,
                  resource_class_args=None, resource_class_kwargs=None):

--- a/flask_apispec/extension.py
+++ b/flask_apispec/extension.py
@@ -54,11 +54,12 @@ class FlaskApiSpec(object):
                     make_apispec(self.app.config.get('APISPEC_TITLE', 'flask-apispec'),
                                  self.app.config.get('APISPEC_VERSION', 'v1'))
 
-        self.register_existing_resources()
         self.add_swagger_routes()
 
         for deferred in self._deferred:
             deferred()
+
+        self.register_existing_resources()
 
     def _defer(self, callable, *args, **kwargs):
         bound = functools.partial(callable, *args, **kwargs)

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import find_packages
 REQUIRES = [
     'six>=1.9.0',
     'flask>=0.10.1',
-    'marshmallow>=2.0',
+    'marshmallow>=2.0.0',
     'webargs>=0.18.0',
     'apispec>=0.17.0',
 ]

--- a/tests/test_extension.py
+++ b/tests/test_extension.py
@@ -63,6 +63,14 @@ class TestExtension:
                       resource_class_kwargs={'arg_two': True})
         assert '/bands/{band_id}/' in docs.spec._paths
 
+    def test_register_existing_resources(self, app, docs):
+        @app.route('/bands/<int:band_id>/')
+        @doc(tags=['band'])
+        def get_band(band_id):
+            return 'queen'
+        docs.register_existing_resources()
+        assert '/bands/{band_id}/' in docs.spec._paths
+
     def test_serve_swagger(self, app, docs, client):
         res = client.get('/swagger/')
         assert res.json == docs.spec.to_dict()


### PR DESCRIPTION
### Summary

##### Register rules on Init
On calling `FlaskApiSpec(app)`, register rules which have already been registered on `app`. This means that in most cases `FlaskApiSpec(app)` should come after calls to `@app.route()` and `app.register_blueprint()` in an app's main method 

##### Changes to empty parameters
Also return an empty list of parameters instead of an object specifying an empty "body" object if a rule does not have a `use_kwargs` decorator.

From:
```json
"parameters": [
     {
        "in": "body", 
        "name": "body", 
        "required": false, 
        "schema": {
              "type": "object"
        }
    }
]
```
to:
```json
"parameters": []
```

### Notes
I would have liked to have a `register_blueprint` function, but I could not for the life of me figure out how to extract the functions from a flask `blueprint` in the way I did with `app.view_functions`, so instead I opted to register all methods on app at init time. 

I can also break this PR up into 2 separate PRs if you think the 2 changes should be reviewed separately.

Lastly, I am just starting to use this library in a large existing project so I may need to make more edits as I go along and discover more features I need.