### PR TITLE
Added examples= to marshall_with

### DIFF
--- a/flask_apispec/annotations.py
+++ b/flask_apispec/annotations.py
@@ -65,7 +65,7 @@ def marshal_with(schema, code='default', description='', inherit=None, apply=Non
             code: {
                 'schema': schema or {},
                 'description': description,
-                'examples' : examples,
+                'examples': examples,
             },
         }
         annotate(func, 'schemas', [options], inherit=inherit, apply=apply)
@@ -83,7 +83,7 @@ def doc(inherit=None, **kwargs):
         @doc(tags=['pet'], description='a pet store')
         def get_pet(pet_id):
             return Pet.query.filter(Pet.id == pet_id).one()
-
+``
     :param inherit: Inherit Swagger documentation from parent classes
     """
     def wrapper(func):

--- a/flask_apispec/annotations.py
+++ b/flask_apispec/annotations.py
@@ -37,7 +37,8 @@ def use_kwargs(args, locations=None, inherit=None, apply=None, **kwargs):
     return wrapper
 
 
-def marshal_with(schema, code='default', description='', inherit=None, apply=None):
+def marshal_with(schema, code='default', description='', inherit=None, apply=None,
+                 examples=None):
     """Marshal the return value of the decorated view function using the
     specified schema.
 
@@ -64,6 +65,7 @@ def marshal_with(schema, code='default', description='', inherit=None, apply=Non
             code: {
                 'schema': schema or {},
                 'description': description,
+                'examples' : examples,
             },
         }
         annotate(func, 'schemas', [options], inherit=inherit, apply=apply)

--- a/flask_apispec/apidoc.py
+++ b/flask_apispec/apidoc.py
@@ -70,10 +70,13 @@ class Converter(object):
             options['default_in'] = locations[0]
         if parse_version(apispec.__version__) < parse_version('0.20.0'):
             options['dump'] = False
-        return converter(
+        rule_params = rule_to_params(rule, docs.get('params')) or []
+        extra_params = converter(
             args.get('args', {}),
             **options
-        ) + rule_to_params(rule, docs.get('params'))
+        ) if args else []
+
+        return rule_params + extra_params
 
     def get_responses(self, view, parent=None):
         annotation = resolve_annotations(view, 'schemas', parent)


### PR DESCRIPTION
The Swagger spec allows one to manually specify examples of operation return values, but currently only `schema` and `description` are parameters to `marshall_with`. This PR adds the ability to specify own example values. 