### PR TITLE
Blueprint and arg fixes

### DIFF
--- a/flask_apispec/extension.py
+++ b/flask_apispec/extension.py
@@ -93,12 +93,17 @@ class FlaskApiSpec(object):
     def register_existing_resources(self):
         for name, rule in self.app.view_functions.items():
             try:
-                blueprint_name, _ = name.split('.')
+                blueprint_name, endpoint_name = name.split('.')
             except ValueError:
+                endpoint_name = name
                 blueprint_name = None
-
+            # don't auto-register ResourceMeta endpoints
+            if hasattr(rule, 'view_class'):
+                view_class = rule.view_class
+                if isinstance(view_class, ResourceMeta):
+                    continue
             try:
-                self.register(rule, blueprint=blueprint_name)
+                self.register(rule, endpoint=endpoint_name, blueprint=blueprint_name)
             except TypeError:
                 pass
 

--- a/flask_apispec/paths.py
+++ b/flask_apispec/paths.py
@@ -23,6 +23,7 @@ def rule_to_params(rule, overrides=None):
     result = [
         argument_to_param(argument, rule, overrides.get(argument, {}))
         for argument in rule.arguments
+        if argument in rule._converters
     ]
     for key in overrides.keys():
         if overrides[key].get('in') in ('header', 'query'):


### PR DESCRIPTION
Fixes three problems:

1) Don't auto-register ResourceMeta-based views that have multiple URLs registered with view_funcs. This allows the standard way of building resourceful APIs with flask MethodViews to work nicely. See http://flask.pocoo.org/docs/0.12/views/#method-views-for-apis

2) Uses the wrong endpoint name when splitting on blueprint name

3) When using a view as in 1), there may be multiple methods mapped to the same view_func, as in the common case of GET /foo and GET /foo/123. The param is incorrectly mapped to the first version because they are both GET methods on the same view func. This fixes that incorrect behavior. Before it would add the path param to the endpoint without any params.