### PR TITLE
Make compatible with Marshmallow >= 3.0.0b7

### DIFF
--- a/flask_apispec/wrapper.py
+++ b/flask_apispec/wrapper.py
@@ -9,6 +9,12 @@ from webargs import flaskparser
 
 from flask_apispec import utils
 
+import marshmallow as ma
+
+MARSHMALLOW_VERSION_INFO = tuple(
+    [int(part) for part in ma.__version__.split('.') if part.isdigit()]
+)
+
 class Wrapper(object):
     """Apply annotations to a view function.
 
@@ -50,7 +56,7 @@ class Wrapper(object):
         if schema and annotation.apply is not False:
             schema = utils.resolve_instance(schema['schema'])
             dumped = schema.dump(unpacked[0])
-            output = dumped.data if core.MARSHMALLOW_VERSION_INFO[0] < 3 else dumped
+            output = dumped.data if MARSHMALLOW_VERSION_INFO[0] < 3 else dumped
         else:
             output = unpacked[0]
         return format_output((format_response(output), ) + unpacked[1:])

--- a/flask_apispec/wrapper.py
+++ b/flask_apispec/wrapper.py
@@ -50,10 +50,7 @@ class Wrapper(object):
         if schema and annotation.apply is not False:
             schema = utils.resolve_instance(schema['schema'])
             dumped = schema.dump(unpacked[0])
-            if isinstance(dumped, dict):
-                output = dumped
-            else:
-                output = dumped.data
+            output = dumped.data if core.MARSHMALLOW_VERSION_INFO[0] < 3 else dumped
         else:
             output = unpacked[0]
         return format_output((format_response(output), ) + unpacked[1:])

--- a/flask_apispec/wrapper.py
+++ b/flask_apispec/wrapper.py
@@ -56,7 +56,7 @@ class Wrapper(object):
         if schema and annotation.apply is not False:
             schema = utils.resolve_instance(schema['schema'])
             dumped = schema.dump(unpacked[0])
-            output = dumped["data"] if MARSHMALLOW_VERSION_INFO[0] < 3 else dumped
+            output = dumped.data if MARSHMALLOW_VERSION_INFO[0] < 3 else dumped
         else:
             output = unpacked[0]
         return format_output((format_response(output), ) + unpacked[1:])

--- a/flask_apispec/wrapper.py
+++ b/flask_apispec/wrapper.py
@@ -49,7 +49,11 @@ class Wrapper(object):
         schema = schemas.get(status_code, schemas.get('default'))
         if schema and annotation.apply is not False:
             schema = utils.resolve_instance(schema['schema'])
-            output = schema.dump(unpacked[0]).data
+            dumped = schema.dump(unpacked[0])
+            if isinstance(dumped, dict):
+                output = dumped
+            else:
+                output = dumped.data
         else:
             output = unpacked[0]
         return format_output((format_response(output), ) + unpacked[1:])

--- a/flask_apispec/wrapper.py
+++ b/flask_apispec/wrapper.py
@@ -54,7 +54,7 @@ class Wrapper(object):
         schemas = utils.merge_recursive(annotation.options)
         schema = schemas.get(status_code, schemas.get('default'))
         if schema and annotation.apply is not False:
-            schema = utils.resolve_instance(schema['schema'])
+            schema = utils.resolve_schema(schema['schema'], request=flask.request)
             dumped = schema.dump(unpacked[0])
             output = dumped.data if MARSHMALLOW_VERSION_INFO[0] < 3 else dumped
         else:

--- a/flask_apispec/wrapper.py
+++ b/flask_apispec/wrapper.py
@@ -56,7 +56,7 @@ class Wrapper(object):
         if schema and annotation.apply is not False:
             schema = utils.resolve_instance(schema['schema'])
             dumped = schema.dump(unpacked[0])
-            output = dumped.data if MARSHMALLOW_VERSION_INFO[0] < 3 else dumped
+            output = dumped["data"] if MARSHMALLOW_VERSION_INFO[0] < 3 else dumped
         else:
             output = unpacked[0]
         return format_output((format_response(output), ) + unpacked[1:])

--- a/flask_apispec/wrapper.py
+++ b/flask_apispec/wrapper.py
@@ -54,7 +54,7 @@ class Wrapper(object):
         schemas = utils.merge_recursive(annotation.options)
         schema = schemas.get(status_code, schemas.get('default'))
         if schema and annotation.apply is not False:
-            schema = utils.resolve_instance(schema['schema'], request=flask.request)
+            schema = utils.resolve_instance(schema['schema'])
             dumped = schema.dump(unpacked[0])
             output = dumped.data if MARSHMALLOW_VERSION_INFO[0] < 3 else dumped
         else:

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -23,9 +23,6 @@ class TestFunctionViews:
         class ArgSchema(Schema):
             name = fields.Str()
 
-            class Meta:
-                strict = True
-
         @app.route('/')
         @use_kwargs(ArgSchema)
         def view(**kwargs):
@@ -61,9 +58,6 @@ class TestFunctionViews:
 
             class ArgSchema(Schema):
                 name = fields.Str()
-
-                class Meta:
-                    strict = True
 
             return ArgSchema
 


### PR DESCRIPTION
Marshmallow has changed the return value of schema.dump(), as per the note in
the API docs:

    http://marshmallow.readthedocs.io/en/latest/api_reference.html#marshmallow.Schema.dump

"Changed in version 3.0.0b7: This method returns the serialized data rather than
a (data, errors) duple. A ValidationError is raised if obj is invalid."

This change just checks the return value of dump().  If it's a dict, it returns
that as output, otherwise, it returns the .data attribute as before.