### PR TITLE
Handling multiple locations in multiple @use_kwargs

### DIFF
--- a/tests/test_swagger.py
+++ b/tests/test_swagger.py
@@ -98,12 +98,12 @@ class TestMultipleLocations:
         class QuerySchema(Schema):
             name = fields.Str()
 
-        class JSONSchema(Schema):
+        class BodySchema(Schema):
             address = fields.Str()
 
         @app.route('/bands/<int:band_id>/')
         @use_kwargs(QuerySchema, locations=('query', ))
-        @use_kwargs(JSONSchema, locations=('json', ))
+        @use_kwargs(BodySchema, locations=('body', ))
         def get_band(**kwargs):
             return kwargs
         return get_band
@@ -126,10 +126,13 @@ class TestMultipleLocations:
                 'required': False,
                 'type': 'string'
             }, {
-                'in': 'json',
-                'name': 'address',
+                'in': 'body',
+                'name': 'body',
                 'required': False,
-                'type': 'string'
+                'schema': {
+                    'properties': {'address': {'type': 'string'}},
+                    'type': 'object'
+                }
             }] + rule_to_params(rule)
         )
         assert params == expected


### PR DESCRIPTION
The Converter.get_parameters merged the options and set the same location for all kinds of parameters in the Swagger spec. An `'in': 'json'`  for this example:

```
@use_kwargs(QuerySchema, locations=('query', ))
@use_kwargs(JSONSchema, locations=('json', ))
def get_band(**kwargs):
    ...
```

This PR fixes that by iterating through the options and setting the right `in` location for all parameters.