### PR TITLE
Use callable as schema within @use_kwargs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,6 @@ docs/_build
 README.html
 
 _sandbox
+
+# JetBrains
+.idea/

--- a/flask_apispec/apidoc.py
+++ b/flask_apispec/apidoc.py
@@ -13,7 +13,7 @@ from marshmallow import Schema
 from marshmallow.utils import is_instance_or_subclass
 
 from flask_apispec.paths import rule_to_path, rule_to_params
-from flask_apispec.utils import resolve_instance, resolve_annotations, merge_recursive
+from flask_apispec.utils import resolve_resource, resolve_annotations, merge_recursive
 
 class Converter(object):
 
@@ -98,4 +98,4 @@ class ResourceConverter(Converter):
         }
 
     def get_parent(self, resource, **kwargs):
-        return resolve_instance(resource, **kwargs)
+        return resolve_resource(resource, **kwargs)

--- a/flask_apispec/utils.py
+++ b/flask_apispec/utils.py
@@ -4,13 +4,12 @@ import functools
 
 import six
 
-def resolve_instance(schema, **kwargs):
-    kwargs = kwargs or {}
+def resolve_resource(resource, **kwargs):
     resource_class_args = kwargs.get('resource_class_args') or ()
     resource_class_kwargs = kwargs.get('resource_class_kwargs') or {}
-    if isinstance(schema, type):
-        return schema(*resource_class_args, **resource_class_kwargs)
-    return schema
+    if isinstance(resource, type):
+        return resource(*resource_class_args, **resource_class_kwargs)
+    return resource
 
 class Ref(object):
 

--- a/flask_apispec/utils.py
+++ b/flask_apispec/utils.py
@@ -4,12 +4,21 @@ import functools
 
 import six
 
+from marshmallow import Schema
+
 def resolve_resource(resource, **kwargs):
     resource_class_args = kwargs.get('resource_class_args') or ()
     resource_class_kwargs = kwargs.get('resource_class_kwargs') or {}
     if isinstance(resource, type):
         return resource(*resource_class_args, **resource_class_kwargs)
     return resource
+
+def resolve_schema(schema, request=None):
+    if isinstance(schema, type) and issubclass(schema, Schema):
+        schema = schema()
+    elif callable(schema):
+        schema = schema(request)
+    return schema
 
 class Ref(object):
 

--- a/flask_apispec/utils.py
+++ b/flask_apispec/utils.py
@@ -3,8 +3,7 @@
 import functools
 
 import six
-
-from marshmallow import Schema
+import marshmallow as ma
 
 def resolve_resource(resource, **kwargs):
     resource_class_args = kwargs.get('resource_class_args') or ()
@@ -14,7 +13,7 @@ def resolve_resource(resource, **kwargs):
     return resource
 
 def resolve_schema(schema, request=None):
-    if isinstance(schema, type) and issubclass(schema, Schema):
+    if isinstance(schema, type) and issubclass(schema, ma.Schema):
         schema = schema()
     elif callable(schema):
         schema = schema(request)

--- a/flask_apispec/wrapper.py
+++ b/flask_apispec/wrapper.py
@@ -33,7 +33,7 @@ class Wrapper(object):
         annotation = utils.resolve_annotations(self.func, 'args', self.instance)
         if annotation.apply is not False:
             for option in annotation.options:
-                schema = utils.resolve_instance(option['args'])
+                schema = utils.resolve_schema(option['args'], request=flask.request)
                 parsed = parser.parse(schema, locations=option['kwargs']['locations'])
                 if getattr(schema, 'many', False):
                     args += tuple(parsed)
@@ -48,7 +48,7 @@ class Wrapper(object):
         schemas = utils.merge_recursive(annotation.options)
         schema = schemas.get(status_code, schemas.get('default'))
         if schema and annotation.apply is not False:
-            schema = utils.resolve_instance(schema['schema'])
+            schema = utils.resolve_schema(schema['schema'], request=flask.request)
             output = schema.dump(unpacked[0]).data
         else:
             output = unpacked[0]

--- a/tests/test_swagger.py
+++ b/tests/test_swagger.py
@@ -91,6 +91,22 @@ class TestArgSchema:
         )
         assert params == expected
 
+class TestCallableAsArgSchema(TestArgSchema):
+
+    @pytest.fixture
+    def function_view(self, app, models, schemas):
+        def schema_factory(request):
+            class ArgSchema(Schema):
+                name = fields.Str()
+
+            return ArgSchema
+
+        @app.route('/bands/<int:band_id>/')
+        @use_kwargs(schema_factory, locations=('query', ))
+        def get_band(**kwargs):
+            return kwargs
+        return get_band
+
 class TestDeleteView:
 
     @pytest.fixture

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -54,6 +54,26 @@ class TestFunctionViews:
         res = client.get('/', {'name': 'freddie', 'instrument': 'vocals'})
         assert res.json == {'name': 'freddie', 'instrument': 'vocals'}
 
+    def test_use_kwargs_callable_as_schema(self, app, client):
+        def schema_factory(request):
+            assert request.method == 'GET'
+            assert request.path == '/'
+
+            class ArgSchema(Schema):
+                name = fields.Str()
+
+                class Meta:
+                    strict = True
+
+            return ArgSchema
+
+        @app.route('/')
+        @use_kwargs(schema_factory)
+        def view(**kwargs):
+            return kwargs
+        res = client.get('/', {'name': 'freddie'})
+        assert res.json == {'name': 'freddie'}
+
     def test_marshal_with_default(self, app, client, models, schemas):
         @app.route('/')
         @marshal_with(schemas.BandSchema)


### PR DESCRIPTION
It is impossible to use schema factory with the `use_kwargs` decorator by analogy with [schema factories at webargs](http://webargs.readthedocs.io/en/latest/advanced.html#schema-factories) so we need to implement it.