### PR TITLE
Limit marshmallow to v2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import find_packages
 REQUIRES = [
     'six>=1.9.0',
     'flask>=0.10.1',
-    'marshmallow>=2.0.0',
+    'marshmallow>=2.0.0,<3.0.0',
     'webargs>=0.18.0',
     'apispec>=0.17.0',
 ]


### PR DESCRIPTION
marshmallow 3.0 only returns data:
http://marshmallow.readthedocs.io/en/latest/upgrading.html
> Schema().load and Schema().dump don’t return a (data, errors) duple any more. Only data is returned.