### PR TITLE
Allow function names for end points to be camelCased

### DIFF
--- a/flask_apispec/__init__.py
+++ b/flask_apispec/__init__.py
@@ -4,7 +4,7 @@ from flask_apispec.annotations import doc, wrap_with, use_kwargs, marshal_with
 from flask_apispec.extension import FlaskApiSpec
 from flask_apispec.utils import Ref
 
-__version__ = '0.6.0.post0'
+__version__ = '0.6.1'
 __all__ = [
     'doc',
     'wrap_with',

--- a/flask_apispec/apidoc.py
+++ b/flask_apispec/apidoc.py
@@ -21,7 +21,7 @@ class Converter(object):
         self.app = app
 
     def convert(self, target, endpoint=None, blueprint=None, **kwargs):
-        endpoint = endpoint or target.__name__.lower()
+        endpoint = endpoint or target.__name__
         if blueprint:
             endpoint = '{}.{}'.format(blueprint, endpoint)
         rules = self.app.url_map._rules_by_endpoint[endpoint]

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ def read(fname):
 
 
 setup(
-    name='flask-apispec',
+    name='flask-apispec-rovanion',
     version=find_version('flask_apispec/__init__.py'),
     description='Build and document REST APIs with Flask and apispec',
     long_description=read('README.rst'),


### PR DESCRIPTION
I have no idea what the rammifications of this change is in the larger scope of this code base and its user. All I really know is that this change to flask_apispec enables it to publish swagger documentation for my project, which uses camelCased function names.