### PR TITLE
Allow function names for end points to be camelCased.

### DIFF
--- a/flask_apispec/apidoc.py
+++ b/flask_apispec/apidoc.py
@@ -21,7 +21,7 @@ class Converter(object):
         self.app = app
 
     def convert(self, target, endpoint=None, blueprint=None, **kwargs):
-        endpoint = endpoint or target.__name__.lower()
+        endpoint = endpoint or target.__name__
         if blueprint:
             endpoint = '{}.{}'.format(blueprint, endpoint)
         rules = self.app.url_map._rules_by_endpoint[endpoint]


### PR DESCRIPTION
I have no idea what the rammifications of this change is in the larger scope of this code base and its user. All I really know is that this change to flask_apispec enables it to publish swagger documentation for my project, which uses camelCased function names.

This PR supersedes #96 as GitHub does not allow that you change the source branch name.