### PR TITLE
Support `return None, 204` when `@marshal_with(None)` is used

### DIFF
--- a/flask_apispec/wrapper.py
+++ b/flask_apispec/wrapper.py
@@ -53,13 +53,16 @@ class Wrapper(object):
         annotation = utils.resolve_annotations(self.func, 'schemas', self.instance)
         schemas = utils.merge_recursive(annotation.options)
         schema = schemas.get(status_code, schemas.get('default'))
-        if schema and annotation.apply is not False:
-            schema = utils.resolve_schema(schema['schema'], request=flask.request)
+        if schema and schema['schema'] and annotation.apply is not False:            
+            schema = utils.resolve_schema(schema['schema'], request=flask.request)            
             dumped = schema.dump(unpacked[0])
             output = dumped.data if MARSHMALLOW_VERSION_INFO[0] < 3 else dumped
         else:
             output = unpacked[0]
+        if not output and status_code == 204:
+            return '', 204
         return format_output((format_response(output), ) + unpacked[1:])
+    
 
 def identity(value):
     return value

--- a/flask_apispec/wrapper.py
+++ b/flask_apispec/wrapper.py
@@ -53,8 +53,8 @@ class Wrapper(object):
         annotation = utils.resolve_annotations(self.func, 'schemas', self.instance)
         schemas = utils.merge_recursive(annotation.options)
         schema = schemas.get(status_code, schemas.get('default'))
-        if schema and schema['schema'] and annotation.apply is not False:            
-            schema = utils.resolve_schema(schema['schema'], request=flask.request)            
+        if schema and schema['schema'] and annotation.apply is not False:
+            schema = utils.resolve_schema(schema['schema'], request=flask.request)
             dumped = schema.dump(unpacked[0])
             output = dumped.data if MARSHMALLOW_VERSION_INFO[0] < 3 else dumped
         else:
@@ -62,7 +62,7 @@ class Wrapper(object):
         if not output and status_code == 204:
             return '', 204
         return format_output((format_response(output), ) + unpacked[1:])
-    
+
 
 def identity(value):
     return value

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -276,3 +276,13 @@ class TestClassViews:
         app.add_url_rule('/<id>/', view_func=ConcreteResource.as_view('concrete'))
         res = client.delete('/5/')
         assert res.body == b''
+
+    def test_schemas_none_tuple_out(self, app, client, models, schemas):
+        class ConcreteResource(MethodResource):
+            @marshal_with(None, code=204)
+            def delete(self, **kwargs):
+                return None, 204
+
+        app.add_url_rule('/<id>/', view_func=ConcreteResource.as_view('concrete'))
+        res = client.delete('/5/')
+        assert res.body == b''


### PR DESCRIPTION
This allows you to return a no-content response like so:

```python
@marshal_with(None, code=204)
def something():
    return None, 204  # or return '', 204
```
So you don't have to `flask.make_response('', 204)` which I found rather confusing.