### PR TITLE
Pin version of apispec to below 0.39.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ REQUIRES = [
     'flask>=0.10.1',
     'marshmallow>=2.0.0',
     'webargs>=0.18.0',
-    'apispec>=0.17.0',
+    'apispec>=0.17.0,<0.39.0',
 ]
 
 def find_version(fname):


### PR DESCRIPTION
Addresses #105 in the laziest way

The actual required change looks more involved, maybe if @sloria can point me in the right direction I can try it out. It looks to me like like the issue is here:
https://github.com/jmcarp/flask-apispec/blob/master/flask_apispec/apidoc.py#L59
