### PR TITLE
apispec>=0.39.0 compatibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,5 @@ _sandbox
 
 # JetBrains
 .idea/
+
+.pytest_cache/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: python
 sudo: false
 env:
-- APISPEC_VERSION="==0.17.0"
+- APISPEC_VERSION="==0.39.0"
 - APISPEC_VERSION=""
 - MARSHMALLOW_VERSION="==2.13.0"
 - MARSHMALLOW_VERSION=""

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,13 @@
 Changelog
 ---------
 
+0.7.0 (unreleased)
+++++++++++++++++++
+
+Features:
+
+* Supports apispec>=0.39.0. Older apispec versions are no longer supported.
+
 0.6.1 (2018-06-25)
 ++++++++++++++++++
 

--- a/README.rst
+++ b/README.rst
@@ -87,13 +87,14 @@ Quickstart
 .. code-block:: python
 
     from apispec import APISpec
+    from apispec.ext.marshmallow import MarshmallowPlugin
     from flask_apispec.extension import FlaskApiSpec
 
     app.config.update({
         'APISPEC_SPEC': APISpec(
             title='pets',
             version='v1',
-            plugins=['apispec.ext.marshmallow'],
+            plugins=[MarshmallowPlugin()],
         ),
         'APISPEC_SWAGGER_URL': '/swagger/',
     })

--- a/flask_apispec/apidoc.py
+++ b/flask_apispec/apidoc.py
@@ -7,7 +7,7 @@ from pkg_resources import parse_version
 
 import apispec
 from apispec.core import VALID_METHODS
-from apispec.ext.marshmallow import swagger
+from apispec.ext.marshmallow import MarshmallowPlugin
 
 from marshmallow import Schema
 from marshmallow.utils import is_instance_or_subclass
@@ -17,8 +17,19 @@ from flask_apispec.utils import resolve_resource, resolve_annotations, merge_rec
 
 class Converter(object):
 
-    def __init__(self, app):
+    def __init__(self, app, spec):
         self.app = app
+        self.spec = spec
+        try:
+            self.marshmallow_plugin = next(
+                plugin for plugin in self.spec.plugins
+                if isinstance(plugin, MarshmallowPlugin)
+            )
+        except StopIteration:
+            raise RuntimeError(
+                "Must have a MarshmallowPlugin instance in the spec's list "
+                'of plugins.'
+            )
 
     def convert(self, target, endpoint=None, blueprint=None, **kwargs):
         endpoint = endpoint or target.__name__.lower()
@@ -57,19 +68,20 @@ class Converter(object):
         return None
 
     def get_parameters(self, rule, view, docs, parent=None):
+        openapi = self.marshmallow_plugin.openapi
         annotation = resolve_annotations(view, 'args', parent)
         args = merge_recursive(annotation.options)
         schema = args.get('args', {})
         if is_instance_or_subclass(schema, Schema):
-            converter = swagger.schema2parameters
+            converter = openapi.schema2parameters
         elif callable(schema):
             schema = schema(request=None)
             if is_instance_or_subclass(schema, Schema):
-                converter = swagger.schema2parameters
+                converter = openapi.schema2parameters
             else:
-                converter = swagger.fields2parameters
+                converter = openapi.fields2parameters
         else:
-            converter = swagger.fields2parameters
+            converter = openapi.fields2parameters
         options = copy.copy(args.get('kwargs', {}))
         locations = options.pop('locations', None)
         if locations:

--- a/flask_apispec/apidoc.py
+++ b/flask_apispec/apidoc.py
@@ -3,9 +3,7 @@
 import copy
 
 import six
-from pkg_resources import parse_version
 
-import apispec
 from apispec.core import VALID_METHODS
 from apispec.ext.marshmallow import MarshmallowPlugin
 
@@ -86,9 +84,6 @@ class Converter(object):
         locations = options.pop('locations', None)
         if locations:
             options['default_in'] = locations[0]
-        if parse_version(apispec.__version__) < parse_version('0.20.0'):
-            options['dump'] = False
-
         options['spec'] = self.app.config.get('APISPEC_SPEC', None)
 
         rule_params = rule_to_params(rule, docs.get('params')) or []

--- a/flask_apispec/extension.py
+++ b/flask_apispec/extension.py
@@ -3,6 +3,7 @@ import flask
 import functools
 import types
 from apispec import APISpec
+from apispec.ext.marshmallow import MarshmallowPlugin
 
 from flask_apispec import ResourceMeta
 from flask_apispec.apidoc import ViewConverter, ResourceConverter
@@ -20,7 +21,7 @@ class FlaskApiSpec(object):
             'APISPEC_SPEC': APISpec(
                 title='pets',
                 version='v1',
-                plugins=['apispec.ext.marshmallow'],
+                plugins=[MarshmallowPlugin()],
             ),
             'APISPEC_SWAGGER_URL': '/swagger/',
         })
@@ -48,13 +49,12 @@ class FlaskApiSpec(object):
 
     def init_app(self, app):
         self.app = app
-        self.view_converter = ViewConverter(self.app)
-        self.resource_converter = ResourceConverter(self.app)
         self.spec = self.app.config.get('APISPEC_SPEC') or \
                     make_apispec(self.app.config.get('APISPEC_TITLE', 'flask-apispec'),
                                  self.app.config.get('APISPEC_VERSION', 'v1'))
-
         self.add_swagger_routes()
+        self.resource_converter = ResourceConverter(self.app, spec=self.spec)
+        self.view_converter = ViewConverter(app=self.app, spec=self.spec)
 
         for deferred in self._deferred:
             deferred()
@@ -150,5 +150,5 @@ def make_apispec(title='flask-apispec', version='v1'):
     return APISpec(
         title=title,
         version=version,
-        plugins=['apispec.ext.marshmallow'],
+        plugins=[MarshmallowPlugin()],
     )

--- a/tests/test_openapi.py
+++ b/tests/test_openapi.py
@@ -27,6 +27,19 @@ def spec(marshmallow_plugin):
 def openapi(marshmallow_plugin):
     return marshmallow_plugin.openapi
 
+
+def test_error_if_spec_does_not_have_marshmallow_plugin(app):
+    bad_spec = APISpec(
+        title='title',
+        version='v1',
+        plugins=[],  # oh no! no MarshmallowPlugin
+    )
+    with pytest.raises(RuntimeError):
+        ViewConverter(app=app, spec=bad_spec)
+    with pytest.raises(RuntimeError):
+        ResourceConverter(app=app, spec=bad_spec)
+
+
 class TestFunctionView:
 
     @pytest.fixture


### PR DESCRIPTION
Fixes compatibility with apispec 0.39.0.

This change is incompatible with older apispec versions.

Fixes #105 