### PR TITLE
Exclude OPTIONS method from operation list

### DIFF
--- a/flask_apispec/apidoc.py
+++ b/flask_apispec/apidoc.py
@@ -45,7 +45,7 @@ class Converter(object):
             'operations': {
                 method.lower(): self.get_operation(rule, view, parent=parent)
                 for method, view in six.iteritems(operations)
-                if method.lower() in (set(VALID_METHODS) - {'head'})
+                if method.lower() in (set(VALID_METHODS) - {'head', 'options'})
             },
         }
 


### PR DESCRIPTION
I have the problem with every endpoint, the OPTIONS method is auto created and showing in Swagger UI.
Options method is rarely used for creating REST API so it is good to ignore this.
Flask endpoint always gives (HEAD, OPTIONS) method by default.