### PR TITLE
Convert `marshal_with` status code to string to prevent json errors when `JSON_SORT_KEYS` is on

### DIFF
--- a/flask_apispec/annotations.py
+++ b/flask_apispec/annotations.py
@@ -62,7 +62,7 @@ def marshal_with(schema, code='default', description='', inherit=None, apply=Non
     """
     def wrapper(func):
         options = {
-            code: {
+            str(code): {
                 'schema': schema or {},
                 'description': description,
             },

--- a/flask_apispec/wrapper.py
+++ b/flask_apispec/wrapper.py
@@ -52,7 +52,7 @@ class Wrapper(object):
         format_response = config.get('APISPEC_FORMAT_RESPONSE', flask.jsonify) or identity
         annotation = utils.resolve_annotations(self.func, 'schemas', self.instance)
         schemas = utils.merge_recursive(annotation.options)
-        schema = schemas.get(status_code, schemas.get('default'))
+        schema = schemas.get(str(status_code), schemas.get('default'))
         if schema and annotation.apply is not False:
             schema = utils.resolve_schema(schema['schema'], request=flask.request)
             dumped = schema.dump(unpacked[0])

--- a/tests/test_extension.py
+++ b/tests/test_extension.py
@@ -3,7 +3,7 @@
 import pytest
 from flask import Blueprint
 
-from flask_apispec import doc
+from flask_apispec import doc, marshal_with
 from flask_apispec.extension import FlaskApiSpec
 from flask_apispec.views import MethodResource
 
@@ -29,6 +29,18 @@ class TestExtension:
         docs.init_app(app)
 
         assert '/bands/{band_id}/' in docs.spec._paths
+
+    def test_generate_spec_mixed_code_types(self, app, docs):
+        @app.route('/intocde')
+        @marshal_with(None)
+        @marshal_with(None, 201)
+        @marshal_with(None, 404)
+        def get_band_intcode():
+            return 'queen', 201
+
+        with app.app_context():
+            docs.register_existing_resources()
+            docs.swagger_json()
 
     def test_register_function(self, app, docs):
         @app.route('/bands/<int:band_id>/')

--- a/tests/test_openapi.py
+++ b/tests/test_openapi.py
@@ -149,7 +149,7 @@ class TestDeleteView:
         return spec._paths['/bands/{band_id}/']
 
     def test_responses(self, schemas, path):
-        response = path['delete']['responses'][204]
+        response = path['delete']['responses']['204']
         assert response['description'] == 'a deleted band'
         assert response['schema'] == {}
 


### PR DESCRIPTION
Hi

I ran into an odd bug caused by a mix of `int` and `str` status codes `marshal_with` decorators on the same route.
E.g. using the flask-apispec `"default"` along with other codes:
```python
@app.route('/')
@marshal_with(SomeSchema)
@marshal_with(OtherSchema, 404)
def view():
    ...
``` 
`json.dumps` converts dict keys to strings silently, but this issue is caused by flask's `jsonify` having `sort_keys` enabled by default which is a hard error for mixed key types on python3.

Test case in the first commit reproduces the issue on python 3.6  
The second commit resolves it by converting status codes to `str` in `marshal_with` and accounting for it in `Wrapper.marshal_result`.

Cheers