### PR TITLE
Adds support for marshmallow `@post_load`

### DIFF
--- a/flask_apispec/wrapper.py
+++ b/flask_apispec/wrapper.py
@@ -1,15 +1,18 @@
 # -*- coding: utf-8 -*-
+try:
+    from collections.abc import Mapping
+except ImportError:  # Python 2
+    from collections import Mapping
 
-from six.moves import http_client as http
 
 import flask
-
+import marshmallow as ma
 import werkzeug
+from six.moves import http_client as http
 from webargs import flaskparser
 
 from flask_apispec import utils
 
-import marshmallow as ma
 
 MARSHMALLOW_VERSION_INFO = tuple(
     [int(part) for part in ma.__version__.split('.') if part.isdigit()]
@@ -43,7 +46,7 @@ class Wrapper(object):
                 parsed = parser.parse(schema, locations=option['kwargs']['locations'])
                 if getattr(schema, 'many', False):
                     args += tuple(parsed)
-                elif getattr(parsed, 'update', False):
+                elif isinstance(parsed, Mapping):
                     kwargs.update(parsed)
                 else:
                     args += (parsed, )

--- a/flask_apispec/wrapper.py
+++ b/flask_apispec/wrapper.py
@@ -43,8 +43,11 @@ class Wrapper(object):
                 parsed = parser.parse(schema, locations=option['kwargs']['locations'])
                 if getattr(schema, 'many', False):
                     args += tuple(parsed)
-                else:
+                elif getattr(parsed, 'update', False):
                     kwargs.update(parsed)
+                else:
+                    args += (parsed, )
+
         return self.func(*args, **kwargs)
 
     def marshal_result(self, unpacked, status_code):

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -35,6 +35,9 @@ class TestFunctionViews:
             def __init__(self, name):
                 self.name = name
 
+            def update(self, name):
+                self.name = name
+
         class ArgSchema(Schema):
             name = fields.Str()
 

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -3,7 +3,7 @@
 import json
 
 from flask import make_response
-from marshmallow import fields, Schema
+from marshmallow import fields, Schema, post_load
 
 from flask_apispec.utils import Ref
 from flask_apispec.views import MethodResource
@@ -29,6 +29,28 @@ class TestFunctionViews:
             return kwargs
         res = client.get('/', {'name': 'freddie'})
         assert res.json == {'name': 'freddie'}
+
+    def test_use_kwargs_schema_with_post_load(self, app, client):
+        class User:
+            def __init__(self, name):
+                self.name = name
+
+        class ArgSchema(Schema):
+            name = fields.Str()
+
+            @post_load
+            def make_object(self, data):
+                return User(**data)
+
+        @app.route('/', methods=('POST', ))
+        @use_kwargs(ArgSchema())
+        def view(user):
+            assert isinstance(user, User)
+            return {'name': user.name}
+
+        data = {'name': 'freddie'}
+        res = client.post('/', data)
+        assert res.json == data
 
     def test_use_kwargs_schema_many(self, app, client):
         class ArgSchema(Schema):


### PR DESCRIPTION
Fixes #103 

Marshmallow `@post_load` decorator can be used as an object factory, to directly return an instance instead of the usual dictionary.

This PR adds support for it, based on https://github.com/jmcarp/flask-apispec/pull/104 plus tests.