### PR TITLE
Add option to exclude OPTIONS requests

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,14 @@
 Changelog
 ---------
 
+0.9.0 (unreleased)
+******************
+
+Features:
+
+* Add option to exclude OPTIONS requests (:issue:`111`).
+  Thanks :user:`Brcrwilliams` for the PR.
+
 0.8.8 (2020-03-29)
 ******************
 

--- a/flask_apispec/apidoc.py
+++ b/flask_apispec/apidoc.py
@@ -15,9 +15,10 @@ from flask_apispec.utils import resolve_resource, resolve_annotations, merge_rec
 
 class Converter(object):
 
-    def __init__(self, app, spec):
+    def __init__(self, app, spec, document_options=True):
         self.app = app
         self.spec = spec
+        self.document_options = document_options
         try:
             self.marshmallow_plugin = next(
                 plugin for plugin in self.spec.plugins
@@ -39,13 +40,16 @@ class Converter(object):
     def get_path(self, rule, target, **kwargs):
         operations = self.get_operations(rule, target)
         parent = self.get_parent(target, **kwargs)
+        excluded_methods = {'head'}
+        if not self.document_options:
+            excluded_methods.add('options')
         return {
             'view': target,
             'path': rule_to_path(rule),
             'operations': {
                 method.lower(): self.get_operation(rule, view, parent=parent)
                 for method, view in six.iteritems(operations)
-                if method.lower() in (set(VALID_METHODS) - {'head'})
+                if method.lower() in (set(VALID_METHODS) - excluded_methods)
             },
         }
 

--- a/flask_apispec/extension.py
+++ b/flask_apispec/extension.py
@@ -35,14 +35,17 @@ class FlaskApiSpec(object):
 
     :param Flask app: App associated with API documentation
     :param APISpec spec: apispec specification associated with API documentation
+    :param bool document_options: Whether or not to include
+        OPTIONS requests in the specification
     """
 
-    def __init__(self, app=None):
+    def __init__(self, app=None, document_options=True):
         self._deferred = []
         self.app = app
         self.view_converter = None
         self.resource_converter = None
         self.spec = None
+        self.document_options = document_options
 
         if app:
             self.init_app(app)
@@ -53,8 +56,10 @@ class FlaskApiSpec(object):
                     make_apispec(self.app.config.get('APISPEC_TITLE', 'flask-apispec'),
                                  self.app.config.get('APISPEC_VERSION', 'v1'))
         self.add_swagger_routes()
-        self.resource_converter = ResourceConverter(self.app, spec=self.spec)
-        self.view_converter = ViewConverter(app=self.app, spec=self.spec)
+        self.resource_converter = ResourceConverter(self.app,
+                                                    self.spec,
+                                                    self.document_options)
+        self.view_converter = ViewConverter(self.app, self.spec, self.document_options)
 
         for deferred in self._deferred:
             deferred()


### PR DESCRIPTION
Fixes #111.
See #112 for prior discussion.

These changes add a new optional parameter called `document_options` to the FlaskApiSpec constructor that will exclude OPTIONS requests from the swagger specification if set to `False`.

Flask automatically generates OPTIONS requests for each route. There are cases, such as when using CORS, where one would want these OPTIONS requests to be generated but do not want to have them in their swagger docs.

My line of reasoning for wanting to exclude these is: My API users will never explicitly make an OPTIONS request. The browser will automatically send a pre-flight OPTIONS request when making a cross-origin request, and I want to have OPTIONS endpoints in order to support that, but I don't want to have this functionality adding a bunch of endpoints to my swagger docs which will largely be ignored by users.