### PR TITLE
update swagger-ui to latest version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,9 +5,9 @@
   "requires": true,
   "dependencies": {
     "swagger-ui-dist": {
-      "version": "3.17.2",
-      "resolved": "https://registry.npmjs.org/swagger-ui-dist/-/swagger-ui-dist-3.17.2.tgz",
-      "integrity": "sha1-wNcN2DP1T37ouL1iRc4uzGgOZ7I="
+      "version": "3.20.4",
+      "resolved": "https://registry.npmjs.org/swagger-ui-dist/-/swagger-ui-dist-3.20.4.tgz",
+      "integrity": "sha512-SR/N+N7EIncEhyA4UGiMQ12vJBSv5OKO4S1g7E7etO+9ZUV6SZ7SqKVC8RDDyMOJzdXgMXV7aGIBIiMSCbEMJw=="
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "flask-apispec",
   "version": "0.7.0",
   "dependencies": {
-    "swagger-ui-dist": "3.17.2"
+    "swagger-ui-dist": "3.20.4"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
The current version that was in use has various bugs when parsing spec files, updating seems to have fixed them for me.