### PR TITLE
support flask-marshmallow

### DIFF
--- a/flask_apispec/__init__.py
+++ b/flask_apispec/__init__.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 from flask_apispec.views import ResourceMeta, MethodResource
-from flask_apispec.annotations import doc, wrap_with, use_kwargs, marshal_with
+from flask_apispec.annotations import doc, wrap_with, use_kwargs, marshal_with, use_args
 from flask_apispec.extension import FlaskApiSpec
 from flask_apispec.utils import Ref
 
@@ -9,6 +9,7 @@ __all__ = [
     'doc',
     'wrap_with',
     'use_kwargs',
+    'use_args',
     'marshal_with',
     'ResourceMeta',
     'MethodResource',

--- a/flask_apispec/__init__.py
+++ b/flask_apispec/__init__.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 from flask_apispec.views import ResourceMeta, MethodResource
-from flask_apispec.annotations import doc, wrap_with, use_kwargs, marshal_with, use_args
+from flask_apispec.annotations import doc, wrap_with, use_kwargs, marshal_with
 from flask_apispec.extension import FlaskApiSpec
 from flask_apispec.utils import Ref
 
@@ -9,7 +9,6 @@ __all__ = [
     'doc',
     'wrap_with',
     'use_kwargs',
-    'use_args',
     'marshal_with',
     'ResourceMeta',
     'MethodResource',

--- a/flask_apispec/annotations.py
+++ b/flask_apispec/annotations.py
@@ -48,9 +48,9 @@ def use_args(args, locations=None, inherit=None, apply=None, **kwargs):
 
         from marshmallow import fields
 
-        @use_args({'name': fields.Str(), 'category': fields.Str()})
-        def create_pet(args):
-            db.session.add(args)
+        @use_args(PetSchema(exclude=('id','created'))
+        def create_pet(pet):
+            db.session.add(pet)
             db.session.commit()
             return args
 

--- a/flask_apispec/annotations.py
+++ b/flask_apispec/annotations.py
@@ -38,6 +38,42 @@ def use_kwargs(args, locations=None, inherit=None, apply=None, **kwargs):
     return wrapper
 
 
+def use_args(args, locations=None, inherit=None, apply=None, **kwargs):
+    """Inject keyword arguments from the specified webargs arguments into the
+    decorated view function.
+
+    Usage:
+
+    .. code-block:: python
+
+        from marshmallow import fields
+
+        @use_args({'name': fields.Str(), 'category': fields.Str()})
+        def create_pet(args):
+            db.session.add(args)
+            db.session.commit()
+            return args
+
+    :param args: Mapping of argument names to :class:`Field <marshmallow.fields.Field>`
+        objects, :class:`Schema <marshmallow.Schema>`, or a callable which accepts a
+        request and returns a :class:`Schema <marshmallow.Schema>`
+    :param locations: Default request locations to parse
+    :param inherit: Inherit args from parent classes
+    :param apply: Parse request with specified args
+    """
+    kwargs.update({'locations': locations})
+
+    def wrapper(func):
+        options = {
+            'args': args,
+            'kwargs': kwargs,
+            'use_args': True
+        }
+        annotate(func, 'args', [options], inherit=inherit, apply=apply)
+        return activate(func)
+    return wrapper
+
+
 def marshal_with(schema, code='default', description='', inherit=None, apply=None):
     """Marshal the return value of the decorated view function using the
     specified schema.

--- a/flask_apispec/annotations.py
+++ b/flask_apispec/annotations.py
@@ -37,43 +37,6 @@ def use_kwargs(args, locations=None, inherit=None, apply=None, **kwargs):
         return activate(func)
     return wrapper
 
-
-def use_args(args, locations=None, inherit=None, apply=None, **kwargs):
-    """Inject keyword arguments from the specified webargs arguments into the
-    decorated view function.
-
-    Usage:
-
-    .. code-block:: python
-
-        from marshmallow import fields
-
-        @use_args(PetSchema(exclude=('id','created'))
-        def create_pet(pet):
-            db.session.add(pet)
-            db.session.commit()
-            return args
-
-    :param args: Mapping of argument names to :class:`Field <marshmallow.fields.Field>`
-        objects, :class:`Schema <marshmallow.Schema>`, or a callable which accepts a
-        request and returns a :class:`Schema <marshmallow.Schema>`
-    :param locations: Default request locations to parse
-    :param inherit: Inherit args from parent classes
-    :param apply: Parse request with specified args
-    """
-    kwargs.update({'locations': locations})
-
-    def wrapper(func):
-        options = {
-            'args': args,
-            'kwargs': kwargs,
-            'use_args': True
-        }
-        annotate(func, 'args', [options], inherit=inherit, apply=apply)
-        return activate(func)
-    return wrapper
-
-
 def marshal_with(schema, code='default', description='', inherit=None, apply=None):
     """Marshal the return value of the decorated view function using the
     specified schema.

--- a/flask_apispec/wrapper.py
+++ b/flask_apispec/wrapper.py
@@ -44,7 +44,10 @@ class Wrapper(object):
                 if getattr(schema, 'many', False):
                     args += tuple(parsed)
                 else:
-                    kwargs.update(parsed)
+                    if 'use_args' in option and option['use_args']:
+                        args += (parsed,)
+                    else:
+                        kwargs.update(parsed)
         return self.func(*args, **kwargs)
 
     def marshal_result(self, unpacked, status_code):


### PR DESCRIPTION
When flask-marshmallow and Sqlalchemy are integrated, an'object is not iterable'error occurs.

So add the function of transforming Sqlalchemy model instance to dict.

```python

class User(db.Model, Timestamp):
    id = db.Column(db.Integer, primary_key=True)
    username = db.Column(db.String(80), unique=True)
    email = db.Column(EmailType())

    def __repr__(self):
        return '<User %r>' % self.username


class UserSchema(ma.ModelSchema):
    class Meta:
        model = User

    email = fields.Email()

@app.route('/users', methods=['POST'])
@doc(tags=['users'], description='create user')
@use_kwargs(UserSchema(exclude=['id','updated','created'], description='create user', required=True)
@marshal_with(UserSchema())
def create_user(**user_info):
    u = User(**user_info)
    db.session.add(u)
    db.session.commit()
    return u
```