### PR TITLE
Handling data parsed as an object

### DIFF
--- a/flask_apispec/wrapper.py
+++ b/flask_apispec/wrapper.py
@@ -44,7 +44,10 @@ class Wrapper(object):
                 if getattr(schema, 'many', False):
                     args += tuple(parsed)
                 else:
-                    kwargs.update(parsed)
+                    if isinstance(parsed, dict):
+                        kwargs.update(parsed)
+                    else:
+                        args, kwargs = (parsed,), {}
         return self.func(*args, **kwargs)
 
     def marshal_result(self, unpacked, status_code):


### PR DESCRIPTION
Hi,

parser.parse returns an object if @postload is used, kwargs.update then fails. It would be nice if the parsed object is passed as an arg instead.

However I'm uncertain if there are any corner cases when this might fail ?

In anyways, thanks for a very convinient library
Marcus 