### PR TITLE
Fix duplicate serialization

### DIFF
--- a/flask_apispec/wrapper.py
+++ b/flask_apispec/wrapper.py
@@ -64,8 +64,8 @@ class Wrapper(object):
             dumped = schema.dump(unpacked[0])
             output = dumped.data if MARSHMALLOW_VERSION_INFO[0] < 3 else dumped
         else:
-            output = unpacked[0]
-        return format_output((format_response(output), ) + unpacked[1:])
+            output = format_response(unpacked[0])
+        return format_output((output, ) + unpacked[1:])
 
 def identity(value):
     return value


### PR DESCRIPTION
Fixes #98 
As far as I can tell this is basically a typo, I can't see any case where you would want the format_response being called on data that's already been serialized by the schema.