### PR TITLE
Fix compatibility with apispec==3.0.0

### DIFF
--- a/flask_apispec/apidoc.py
+++ b/flask_apispec/apidoc.py
@@ -4,6 +4,7 @@ import copy
 
 import six
 
+import apispec
 from apispec.core import VALID_METHODS
 from apispec.ext.marshmallow import MarshmallowPlugin
 
@@ -12,6 +13,10 @@ from marshmallow.utils import is_instance_or_subclass
 
 from flask_apispec.paths import rule_to_path, rule_to_params
 from flask_apispec.utils import resolve_resource, resolve_annotations, merge_recursive
+
+APISPEC_VERSION_INFO = tuple(
+    [int(part) for part in apispec.__version__.split('.') if part.isdigit()]
+)
 
 class Converter(object):
 
@@ -67,7 +72,10 @@ class Converter(object):
         return None
 
     def get_parameters(self, rule, view, docs, parent=None):
-        openapi = self.marshmallow_plugin.openapi
+        if APISPEC_VERSION_INFO[0] < 3:
+            openapi = self.marshmallow_plugin.openapi
+        else:
+            openapi = self.marshmallow_plugin.converter
         annotation = resolve_annotations(view, 'args', parent)
         extra_params = []
         for args in annotation.options:

--- a/tests/test_openapi.py
+++ b/tests/test_openapi.py
@@ -9,7 +9,7 @@ from flask import make_response
 from flask_apispec.paths import rule_to_params
 from flask_apispec.views import MethodResource
 from flask_apispec import doc, use_kwargs, marshal_with
-from flask_apispec.apidoc import ViewConverter, ResourceConverter
+from flask_apispec.apidoc import APISPEC_VERSION_INFO, ViewConverter, ResourceConverter
 
 @pytest.fixture()
 def marshmallow_plugin():
@@ -26,7 +26,10 @@ def spec(marshmallow_plugin):
 
 @pytest.fixture()
 def openapi(marshmallow_plugin):
-    return marshmallow_plugin.openapi
+    if APISPEC_VERSION_INFO[0] < 3:
+        return marshmallow_plugin.openapi
+    else:
+        return marshmallow_plugin.converter
 
 def ref_path(spec):
     if spec.openapi_version.version[0] < 3:


### PR DESCRIPTION
It's a quick fix which resolves #163.

@sloria I think there should be test matrix for Tox to run tests against different versions of `apispec`, not only `marshmallow`.