### PR TITLE
Update extension.py

### DIFF
--- a/flask_apispec/extension.py
+++ b/flask_apispec/extension.py
@@ -69,7 +69,7 @@ class FlaskApiSpec(object):
 
     def add_swagger_routes(self):
         blueprint = flask.Blueprint(
-            'flask-apispec',
+            self.app.config.get('APISPEC_BLUEPRINT_NAME', 'flask-apispec'),
             __name__,
             static_folder='./static',
             template_folder='./templates',


### PR DESCRIPTION
Adding APISPEC_BLUEPRINT_NAME, to prevent Error:

AssertionError: A name collision occurred between blueprints <flask.blueprints.Blueprint object at 0x11f474cc0> and <flask.blueprints.Blueprint object at 0x11ee7b898>. Both share the same name "flask-apispec". Blueprints that are created on the fly need unique names.

When trying to create 2 separate swagger endpoints for a set of resources. (i.e Public and Private)