### PR TITLE
Fix serialisation problem with return codes when used with flask-restful

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,14 @@
 Changelog
 ---------
 
+0.8.4 (unreleased)
+******************
+
+Bug fixes:
+
+* Fix serialisation problem with return codes when used with flask-restful  (:issue:`98`, :issue:`93`).
+  Thanks :user:`AdamLeyshon` for the PR.
+
 0.8.3 (2019-09-17)
 ******************
 

--- a/flask_apispec/wrapper.py
+++ b/flask_apispec/wrapper.py
@@ -1,9 +1,10 @@
 # -*- coding: utf-8 -*-
+from flask import Response
+
 try:
     from collections.abc import Mapping
 except ImportError:  # Python 2
     from collections import Mapping
-
 
 import flask
 import marshmallow as ma
@@ -13,10 +14,10 @@ from webargs import flaskparser
 
 from flask_apispec import utils
 
-
 MARSHMALLOW_VERSION_INFO = tuple(
-    [int(part) for part in ma.__version__.split('.') if part.isdigit()]
+        [int(part) for part in ma.__version__.split('.') if part.isdigit()]
 )
+
 
 class Wrapper(object):
     """Apply annotations to a view function.
@@ -24,6 +25,7 @@ class Wrapper(object):
     :param func: View function to wrap
     :param instance: Optional instance or parent
     """
+
     def __init__(self, func, instance=None):
         self.func = func
         self.instance = instance
@@ -49,7 +51,7 @@ class Wrapper(object):
                 elif isinstance(parsed, Mapping):
                     kwargs.update(parsed)
                 else:
-                    args += (parsed, )
+                    args += (parsed,)
 
         return self.func(*args, **kwargs)
 
@@ -65,14 +67,20 @@ class Wrapper(object):
             output = dumped.data if MARSHMALLOW_VERSION_INFO[0] < 3 else dumped
         else:
             output = unpacked[0]
-        return format_output((format_response(output), ) + unpacked[1:])
+
+        response_object = format_response(output)  # type: Response
+        response_object.status_code = unpacked[1] or 200
+        return format_output((response_object,))
+
 
 def identity(value):
     return value
 
+
 def unpack(resp):
-    resp = resp if isinstance(resp, tuple) else (resp, )
-    return resp + (None, ) * (3 - len(resp))
+    resp = resp if isinstance(resp, tuple) else (resp,)
+    return resp + (None,) * (3 - len(resp))
+
 
 def format_output(values):
     while values[-1] is None:

--- a/flask_apispec/wrapper.py
+++ b/flask_apispec/wrapper.py
@@ -15,7 +15,7 @@ from webargs import flaskparser
 from flask_apispec import utils
 
 MARSHMALLOW_VERSION_INFO = tuple(
-        [int(part) for part in ma.__version__.split('.') if part.isdigit()]
+    [int(part) for part in ma.__version__.split('.') if part.isdigit()]
 )
 
 


### PR DESCRIPTION
by using the unpacked status in the tuple tuple or default to 200.

Then return a tuple consisting only of the response object allowing
flask-restful to unpack and serialise the response properly.

I believe this will still work for people without flask-restful too.
All the tests in the suite passed.