### PR TITLE
Add static url variables to init

### DIFF
--- a/flask_apispec/extension.py
+++ b/flask_apispec/extension.py
@@ -35,15 +35,24 @@ class FlaskApiSpec(object):
         docs.register(get_pet)
 
     :param Flask app: App associated with API documentation
+    :param String static_folder: Static files folder location
+    :param String template_folder: Template files folder location
+    :param String static_url_path: URL to serve static files
     :param APISpec spec: apispec specification associated with API documentation
     """
 
-    def __init__(self, app=None):
+    def __init__(self, app=None,
+                 static_folder='./static',
+                 template_folder='./templates',
+                 static_url_path='/flask-apispec/static'):
         self._deferred = []
         self.app = app
         self.view_converter = None
         self.resource_converter = None
         self.spec = None
+        self.static_folder = static_folder
+        self.template_folder = template_folder
+        self.static_url_path = static_url_path
 
         if app:
             self.init_app(app)
@@ -71,9 +80,9 @@ class FlaskApiSpec(object):
         blueprint = flask.Blueprint(
             'flask-apispec',
             __name__,
-            static_folder='./static',
-            template_folder='./templates',
-            static_url_path='/flask-apispec/static',
+            static_folder=self.static_folder,
+            template_folder=self.template_folder,
+            static_url_path=self.static_url_path,
         )
 
         json_url = self.app.config.get('APISPEC_SWAGGER_URL', '/swagger/')


### PR DESCRIPTION
This is done so that the user can change the url where the static files are served from. In case the swagger ui is served from behind a gateway.