### PR TITLE
apidoc: Add default_in=None by default

### DIFF
--- a/flask_apispec/apidoc.py
+++ b/flask_apispec/apidoc.py
@@ -94,7 +94,7 @@ class Converter(object):
             locations = options.pop('locations', None)
             if locations:
                 options['default_in'] = locations[0]
-            else:
+            elif 'default_in' not in options:
                 options['default_in'] = 'body'
             extra_params += converter(schema, **options) if args else []
 

--- a/tests/test_openapi.py
+++ b/tests/test_openapi.py
@@ -245,7 +245,7 @@ class TestMultipleLocations:
         assert params == expected
 
 
-class TestFiledsNoLocationProvided:
+class TestGetFieldsNoLocationProvided:
 
     @pytest.fixture
     def function_view(self, app):
@@ -266,26 +266,19 @@ class TestFiledsNoLocationProvided:
 
     def test_params(self, app, path):
         params = path['get']['parameters']
-        rule = app.url_map._rules_by_endpoint['get_band'][0]
-        expected = (
-                [{
-                    'in': 'body',
-                    'name': 'body',
-                    'required': False,
-                    'schema': {
-                        'properties': {
-                            'address': {
-                                'type': 'string'
-                            },
-                            'name': {
-                                'type': 'string'
-                            }
-                        },
-                        'type': 'object'
-                    },
-                }] + rule_to_params(rule)
-        )
-        assert params == expected
+        assert {
+            'in': 'body',
+            'name': 'body',
+            'required': False,
+            'schema': {
+                'properties': {
+                    'address': {'type': 'string'},
+                    'name': {'type': 'string'},
+                },
+                'type': 'object',
+            },
+        } in params
+
 
 class TestSchemaNoLocationProvided:
 
@@ -310,13 +303,5 @@ class TestSchemaNoLocationProvided:
 
     def test_params(self, app, path):
         params = path['get']['parameters']
-        rule = app.url_map._rules_by_endpoint['get_band'][0]
-        expected = (
-                [{
-                    'in': 'body',
-                    'name': 'body',
-                    'required': False,
-                    'schema': {'$ref': '#/definitions/Body'}
-                }] + rule_to_params(rule)
-        )
-        assert params == expected
+        assert {'name': 'body', 'in': 'body', 'required': False,
+                'schema': {'$ref': '#/definitions/Body'}} in params


### PR DESCRIPTION
default_in was changed to a mandatory kwarg parameter
in apispec 3.x
In a flask-apispec 0.8.4 this was changed to be set to "body"

But this does not work correctly for GET urls where the params
should be set to query-params by default.