### PR TITLE
Restrict webargs versions

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ REQUIRES = [
     'flask>=0.10.1',
     'marshmallow>=2.0.0,<3.0.0rc6; python_version<"3"',
     'marshmallow>=2.0.0; python_version>="3"',
-    'webargs>=0.18.0',
+    'webargs>=0.18.0,<6.0.0',
     'apispec>=1.0.0',
 ]
 


### PR DESCRIPTION
webargs 6.0.0 has incompatible changes for example:
 - [Parser.use_args and Parser.use_kwargs now accept location (singular) instead
   of locations (plurala)](https://github.com/marshmallow-code/webargs/blob/dev/CHANGELOG.rst#600b1-2020-01-06)

close: #176