### PR TITLE
Return Response Object from View Functions

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,16 @@
 Changelog
 ---------
 
+0.8.8 (unreleased)
+******************
+
+Bug fixes:
+
+* Fix behavior when view returns ``(obj, status_code, headers)``
+  (regression in 0.8.7) (:issue:`181`).
+  Thanks :user:`decaz` for reporting and thanks :user:`c-kruse`
+  for the PR.
+
 0.8.7 (2020-03-10)
 ******************
 

--- a/flask_apispec/wrapper.py
+++ b/flask_apispec/wrapper.py
@@ -36,8 +36,8 @@ class Wrapper(object):
             return response
         rv, status_code, headers = unpack(response)
         mv = self.marshal_result(rv, status_code)
-        resposne = packed(mv, status_code, headers)
-        return flask.current_app.make_response(resposne)
+        response = packed(mv, status_code, headers)
+        return flask.current_app.make_response(response)
 
     def call_view(self, *args, **kwargs):
         config = flask.current_app.config

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -19,6 +19,37 @@ class TestFunctionViews:
         res = client.get('/', {'name': 'freddie'})
         assert res.json == {'name': 'freddie'}
 
+    def test_view_returning_tuple(self, app, client):
+        @app.route('/all')
+        @use_kwargs({'name': fields.Str()})
+        def all(**kwargs):
+            return kwargs, 202, {'x-msg': 'test'}
+
+        @app.route('/headers')
+        @use_kwargs({'name': fields.Str()})
+        def view_headers(**kwargs):
+            return kwargs, {'x-msg': 'test'}
+
+        @app.route('/code')
+        @use_kwargs({'name': fields.Str()})
+        def view_code(**kwargs):
+            return kwargs, 202
+
+        res_all = client.get('/all', {'name': 'freddie'})
+        assert res_all.json == {'name': 'freddie'}
+        assert res_all.status_code == 202
+        assert res_all.headers.get('x-msg') == 'test'
+
+        res_headers = client.get('/headers', {'name': 'freddie'})
+        assert res_headers.json == {'name': 'freddie'}
+        assert res_headers.status_code == 200
+        assert res_headers.headers.get('x-msg') == 'test'
+
+        res_code = client.get('/code', {'name': 'freddie'})
+        assert res_code.json == {'name': 'freddie'}
+        assert res_code.status_code == 202
+        assert 'x-msg' not in res_code.headers
+
     def test_use_kwargs_schema(self, app, client):
         class ArgSchema(Schema):
             name = fields.Str()


### PR DESCRIPTION
## Fixes 🤞 
"Version 0.8.7 regression" https://github.com/jmcarp/flask-apispec/issues/181 @decaz 

## Caused by
"Fix serialization problem with return codes when used with flask-restful" https://github.com/jmcarp/flask-apispec/pull/168 @AdamLeyshon 

## What?

Flask gives developers a lot of leeway when it comes view function return values ([flask docs](https://flask.palletsprojects.com/en/1.1.x/quickstart/#about-responses).) Flask-Restful did not play well with the particular structure pre 0.8.7, flask-apispec's decorators were using.

Pre 0.8.7 flask-apispec's decorators return a tuple with the first value being a Response object, and optionally a second and third value for the status_code and headers. [See point in time here.](https://github.com/jmcarp/flask-apispec/blob/55255f5c30cacb7dd14668ed5e01cb9e03280419/flask_apispec/wrapper.py#L68). In https://github.com/jmcarp/flask-apispec/pull/168 we attempted to fix this by returning a tuple containing only a response object (neglecting to update the headers.)

In this PR, I try and unpack the view function's return value in a safer way (acknowledging the possibility of someone wanting to return a tuple with `(response, headers)`). Then letting `marshal_result` just worry about marshaling, and using flask's `make_response` to return a Response object with updated status code and headers.