### PR TITLE
Bump to webargs 6.0+; drop python 2 and marshmallow 2 compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ env:
 - MARSHMALLOW_VERSION="==2.13.0"
 - MARSHMALLOW_VERSION=""
 python:
-- '2.7'
 - '3.5'
 - '3.6'
 before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: python
 cache: pip
 sudo: false
 env:
-- MARSHMALLOW_VERSION="==2.13.0"
+- MARSHMALLOW_VERSION="==3.0.0"
 - MARSHMALLOW_VERSION=""
 python:
 - '3.5'

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -26,7 +26,7 @@ issues_github_path = 'jmcarp/flask-apispec'
 source_suffix = '.rst'
 master_doc = 'index'
 project = 'flask-apispec'
-copyright = 'Joshua Carp and contributors {0:%Y}'.format(dt.datetime.utcnow())
+copyright = 'Joshua Carp and contributors {:%Y}'.format(dt.datetime.utcnow())
 
 version = release = flask_apispec.__version__
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,6 +1,3 @@
-# -*- coding: utf-8 -*-
-from __future__ import unicode_literals
-
 import datetime as dt
 import os
 import sys

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -2,7 +2,6 @@ sphinx
 sphinx-issues
 sphinx-rtd-theme
 
-six
 flask
 apispec
 webargs

--- a/examples/petstore.py
+++ b/examples/petstore.py
@@ -1,20 +1,20 @@
-# -*- coding: utf-8 -*-
-
-import six
 import marshmallow as ma
 
 from flask_apispec import ResourceMeta, Ref, doc, marshal_with, use_kwargs
+
 
 class Pet:
     def __init__(self, name, type):
         self.name = name
         self.type = type
 
+
 class PetSchema(ma.Schema):
     name = ma.fields.Str()
     type = ma.fields.Str()
 
-class PetResource(six.with_metaclass(ResourceMeta)):
+
+class PetResource(metaclass=ResourceMeta):
     @use_kwargs({
         'category': ma.fields.Str(),
         'name': ma.fields.Str(),
@@ -22,6 +22,7 @@ class PetResource(six.with_metaclass(ResourceMeta)):
     @marshal_with(PetSchema(), code=200)
     def get(self):
         return Pet('calici', 'cat')
+
 
 class CatResource(PetResource):
     @use_kwargs({'category': ma.fields.Int()})
@@ -31,7 +32,7 @@ class CatResource(PetResource):
 
 ###
 
-class CrudResource(six.with_metaclass(ResourceMeta)):
+class CrudResource(metaclass=ResourceMeta):
 
     schema = None
 
@@ -51,6 +52,7 @@ class CrudResource(six.with_metaclass(ResourceMeta)):
     @marshal_with(None, code=204)
     def delete(self, id):
         pass
+
 
 class PetResource(CrudResource):
     schema = PetSchema
@@ -77,7 +79,7 @@ docs.register(get_pet)
 class MethodResourceMeta(ResourceMeta, flask.views.MethodViewType):
     pass
 
-class MethodResource(six.with_metaclass(MethodResourceMeta, flask.views.MethodView)):
+class MethodResource(flask.views.MethodView, metaclass=MethodResourceMeta):
     methods = None
 
 @doc(

--- a/flask_apispec/__init__.py
+++ b/flask_apispec/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 from flask_apispec.views import ResourceMeta, MethodResource
 from flask_apispec.annotations import doc, wrap_with, use_kwargs, marshal_with
 from flask_apispec.extension import FlaskApiSpec

--- a/flask_apispec/annotations.py
+++ b/flask_apispec/annotations.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 import functools
 
 from flask_apispec import utils
@@ -73,6 +71,7 @@ def marshal_with(schema, code='default', description='', inherit=None, apply=Non
         return activate(func)
     return wrapper
 
+
 def doc(inherit=None, **kwargs):
     """Annotate the decorated view function or class with the specified Swagger
     attributes.
@@ -92,6 +91,7 @@ def doc(inherit=None, **kwargs):
         return activate(func)
     return wrapper
 
+
 def wrap_with(wrapper_cls):
     """Use a custom `Wrapper` to apply annotations to the decorated function.
 
@@ -102,10 +102,12 @@ def wrap_with(wrapper_cls):
         return activate(func)
     return wrapper
 
+
 def annotate(func, key, options, **kwargs):
     annotation = utils.Annotation(options, **kwargs)
     func.__apispec__ = func.__dict__.get('__apispec__', {})
     func.__apispec__.setdefault(key, []).insert(0, annotation)
+
 
 def activate(func):
     if isinstance(func, type) or getattr(func, '__apispec__', {}).get('wrapped'):

--- a/flask_apispec/annotations.py
+++ b/flask_apispec/annotations.py
@@ -5,7 +5,8 @@ import functools
 from flask_apispec import utils
 from flask_apispec.wrapper import Wrapper
 
-def use_kwargs(args, locations=None, inherit=None, apply=None, **kwargs):
+
+def use_kwargs(args, location=None, inherit=None, apply=None, **kwargs):
     """Inject keyword arguments from the specified webargs arguments into the
     decorated view function.
 
@@ -22,11 +23,12 @@ def use_kwargs(args, locations=None, inherit=None, apply=None, **kwargs):
     :param args: Mapping of argument names to :class:`Field <marshmallow.fields.Field>`
         objects, :class:`Schema <marshmallow.Schema>`, or a callable which accepts a
         request and returns a :class:`Schema <marshmallow.Schema>`
-    :param locations: Default request locations to parse
+    :param location: Default request location to parse
     :param inherit: Inherit args from parent classes
     :param apply: Parse request with specified args
     """
-    kwargs.update({'locations': locations})
+
+    kwargs.update({'location': location})
 
     def wrapper(func):
         options = {

--- a/flask_apispec/apidoc.py
+++ b/flask_apispec/apidoc.py
@@ -1,8 +1,4 @@
-# -*- coding: utf-8 -*-
-
 import copy
-
-import six
 
 import apispec
 from apispec.core import VALID_METHODS
@@ -18,7 +14,7 @@ APISPEC_VERSION_INFO = tuple(
     [int(part) for part in apispec.__version__.split('.') if part.isdigit()]
 )
 
-class Converter(object):
+class Converter:
 
     def __init__(self, app, spec, document_options=True):
         self.app = app
@@ -54,7 +50,7 @@ class Converter(object):
             'path': rule_to_path(rule),
             'operations': {
                 method.lower(): self.get_operation(rule, view, parent=parent)
-                for method, view in six.iteritems(operations)
+                for method, view in operations.items()
                 if method.lower() in (set(valid_methods) - excluded_methods)
             },
         }

--- a/flask_apispec/apidoc.py
+++ b/flask_apispec/apidoc.py
@@ -95,9 +95,9 @@ class Converter(object):
             else:
                 converter = openapi.fields2parameters
             options = copy.copy(args.get('kwargs', {}))
-            locations = options.pop('locations', None)
-            if locations:
-                options['default_in'] = locations[0]
+            location = options.pop('location', None)
+            if location:
+                options['default_in'] = location
             elif 'default_in' not in options:
                 options['default_in'] = 'body'
             extra_params += converter(schema, **options) if args else []

--- a/flask_apispec/extension.py
+++ b/flask_apispec/extension.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import flask
 import functools
 import types
@@ -9,7 +8,7 @@ from flask_apispec import ResourceMeta
 from flask_apispec.apidoc import ViewConverter, ResourceConverter
 
 
-class FlaskApiSpec(object):
+class FlaskApiSpec:
     """Flask-apispec extension.
 
     Usage:

--- a/flask_apispec/paths.py
+++ b/flask_apispec/paths.py
@@ -1,10 +1,9 @@
-# -*- coding: utf-8 -*-
-
 import re
 
 import werkzeug.routing
 
 PATH_RE = re.compile(r'<(?:[^:<>]+:)?([^<>]+)>')
+
 
 def rule_to_path(rule):
     return PATH_RE.sub(r'{\1}', rule.rule)
@@ -17,6 +16,7 @@ CONVERTER_MAPPING = {
 }
 
 DEFAULT_TYPE = ('string', None)
+
 
 def rule_to_params(rule, overrides=None):
     overrides = (overrides or {})

--- a/flask_apispec/utils.py
+++ b/flask_apispec/utils.py
@@ -1,9 +1,7 @@
-# -*- coding: utf-8 -*-
-
 import functools
 
-import six
 import marshmallow as ma
+
 
 def resolve_resource(resource, **kwargs):
     resource_class_args = kwargs.get('resource_class_args') or ()
@@ -12,6 +10,7 @@ def resolve_resource(resource, **kwargs):
         return resource(*resource_class_args, **resource_class_kwargs)
     return resource
 
+
 def resolve_schema(schema, request=None):
     if isinstance(schema, type) and issubclass(schema, ma.Schema):
         schema = schema()
@@ -19,7 +18,7 @@ def resolve_schema(schema, request=None):
         schema = schema(request)
     return schema
 
-class Ref(object):
+class Ref:
 
     def __init__(self, key):
         self.key = key
@@ -27,11 +26,12 @@ class Ref(object):
     def resolve(self, obj):
         return getattr(obj, self.key, None)
 
+
 def resolve_refs(obj, attr):
     if isinstance(attr, dict):
         return {
             key: resolve_refs(obj, value)
-            for key, value in six.iteritems(attr)
+            for key, value in attr.items()
         }
     if isinstance(attr, list):
         return [resolve_refs(obj, value) for value in attr]
@@ -39,7 +39,7 @@ def resolve_refs(obj, attr):
         return attr.resolve(obj)
     return attr
 
-class Annotation(object):
+class Annotation:
 
     def __init__(self, options=None, inherit=None, apply=None):
         self.options = options or []

--- a/flask_apispec/views.py
+++ b/flask_apispec/views.py
@@ -1,9 +1,7 @@
-# -*- coding: utf-8 -*-
-
-import six
 import flask.views
 
 from flask_apispec.annotations import activate
+
 
 def inherit(child, parents):
     child.__apispec__ = child.__dict__.get('__apispec__', {})
@@ -15,17 +13,18 @@ def inherit(child, parents):
             if annotation not in child.__apispec__[key]
         )
 
+
 class ResourceMeta(type):
 
     def __new__(mcs, name, bases, attrs):
-        klass = super(ResourceMeta, mcs).__new__(mcs, name, bases, attrs)
+        klass = super().__new__(mcs, name, bases, attrs)
         mro = klass.mro()
         inherit(klass, mro[1:])
         methods = [
             each.lower() for each in
             getattr(klass, 'methods', None) or flask.views.http_method_funcs
         ]
-        for key, value in six.iteritems(attrs):
+        for key, value in attrs.items():
             if key.lower() in methods:
                 parents = [
                     getattr(parent, key) for parent in mro
@@ -38,10 +37,12 @@ class ResourceMeta(type):
                     value.__apispec__['ismethod'] = True
         return klass
 
+
 class MethodResourceMeta(ResourceMeta, flask.views.MethodViewType):
     pass
 
-class MethodResource(six.with_metaclass(MethodResourceMeta, flask.views.MethodView)):
+
+class MethodResource(flask.views.MethodView, metaclass=MethodResourceMeta):
     """Subclass of `MethodView` that uses the `ResourceMeta` metaclass. Behaves
     exactly like `MethodView` but inherits **flask-apispec** annotations.
     """

--- a/flask_apispec/wrapper.py
+++ b/flask_apispec/wrapper.py
@@ -45,7 +45,7 @@ class Wrapper(object):
         if annotation.apply is not False:
             for option in annotation.options:
                 schema = utils.resolve_schema(option['args'], request=flask.request)
-                parsed = parser.parse(schema, locations=option['kwargs']['locations'])
+                parsed = parser.parse(schema, location=option['kwargs']['location'])
                 if getattr(schema, 'many', False):
                     args += tuple(parsed)
                 elif isinstance(parsed, Mapping):

--- a/flask_apispec/wrapper.py
+++ b/flask_apispec/wrapper.py
@@ -1,4 +1,4 @@
-# from flask import Response
+from flask import Response
 
 from collections.abc import Mapping
 

--- a/flask_apispec/wrapper.py
+++ b/flask_apispec/wrapper.py
@@ -1,10 +1,6 @@
-# -*- coding: utf-8 -*-
-from flask import Response
+# from flask import Response
 
-try:
-    from collections.abc import Mapping
-except ImportError:  # Python 2
-    from collections import Mapping
+from collections.abc import Mapping
 
 import flask
 import marshmallow as ma
@@ -18,7 +14,7 @@ MARSHMALLOW_VERSION_INFO = tuple(
 )
 
 
-class Wrapper(object):
+class Wrapper:
     """Apply annotations to a view function.
 
     :param func: View function to wrap

--- a/setup.py
+++ b/setup.py
@@ -5,10 +5,8 @@ from setuptools import setup
 from setuptools import find_packages
 
 REQUIRES = [
-    'six>=1.9.0',
     'flask>=0.10.1',
-    'marshmallow>=2.0.0,<3.0.0rc6; python_version<"3"',
-    'marshmallow>=2.0.0; python_version>="3"',
+    'marshmallow>=2.0.0',
     'webargs>=6.0.0',
     'apispec>=1.0.0',
 ]
@@ -29,6 +27,7 @@ def find_version(fname):
     if not version:
         raise RuntimeError('Cannot find version information')
     return version
+
 
 def read(fname):
     with open(fname) as fp:
@@ -51,17 +50,7 @@ setup(
     license='MIT',
     zip_safe=False,
     keywords='flask marshmallow webargs apispec',
-    classifiers=[
-        'Development Status :: 4 - Beta',
-        'Intended Audience :: Developers',
-        'License :: OSI Approved :: MIT License',
-        'Natural Language :: English',
-        'Programming Language :: Python :: 2',
-        'Programming Language :: Python :: 2.7',
-        'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.5',
-        'Programming Language :: Python :: 3.6',
-    ],
+    python_requires=">=3.5",
     test_suite='tests',
     project_urls={
         'Bug Reports': 'https://github.com/jmcarp/flask-apispec/issues',

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 import re
 from setuptools import setup
 from setuptools import find_packages
@@ -17,7 +15,7 @@ def find_version(fname):
     Raises RuntimeError if not found.
     """
     version = ''
-    with open(fname, 'r') as fp:
+    with open(fname) as fp:
         reg = re.compile(r'__version__ = [\'"]([^\'"]*)[\'"]')
         for line in fp:
             m = reg.match(line)

--- a/setup.py
+++ b/setup.py
@@ -9,9 +9,10 @@ REQUIRES = [
     'flask>=0.10.1',
     'marshmallow>=2.0.0,<3.0.0rc6; python_version<"3"',
     'marshmallow>=2.0.0; python_version>="3"',
-    'webargs>=0.18.0,<6.0.0',
+    'webargs>=6.0.0',
     'apispec>=1.0.0',
 ]
+
 
 def find_version(fname):
     """Attempts to find the version number in the file names fname.

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ from setuptools import find_packages
 
 REQUIRES = [
     'flask>=0.10.1',
-    'marshmallow>=2.0.0',
+    'marshmallow>=3.0.0',
     'webargs>=6.0.0',
     'apispec>=1.0.0',
 ]

--- a/tasks.py
+++ b/tasks.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import os
 import sys
 import webbrowser
@@ -30,7 +29,7 @@ def browse_docs(ctx):
     webbrowser.open_new_tab(path)
 
 def build_docs(ctx, browse):
-    ctx.run("sphinx-build %s %s" % (docs_dir, build_dir), echo=True)
+    ctx.run("sphinx-build {} {}".format(docs_dir, build_dir), echo=True)
     if browse:
         browse_docs(ctx)
 
@@ -54,7 +53,7 @@ def watch_docs(ctx, browse=False):
         print('Install it with:')
         print('    pip install sphinx-autobuild')
         sys.exit(1)
-    ctx.run('sphinx-autobuild {0} {1} {2} -z marshmallow'.format(
+    ctx.run('sphinx-autobuild {} {} {} -z marshmallow'.format(
         '--open-browser' if browse else '', docs_dir, build_dir), echo=True, pty=True)
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 import flask
 
 import pytest
@@ -7,7 +5,7 @@ import webtest
 
 import marshmallow as ma
 
-class Bunch(object):
+class Bunch:
 
     def __init__(self, **kwargs):
         self.__dict__.update(**kwargs)
@@ -27,7 +25,7 @@ def client(app):
 
 @pytest.fixture
 def models():
-    class Band(object):
+    class Band:
         def __init__(self, name, genre):
             self.name = name
             self.genre = genre

--- a/tests/test_extension.py
+++ b/tests/test_extension.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 import pytest
 from flask import Blueprint
 

--- a/tests/test_openapi.py
+++ b/tests/test_openapi.py
@@ -54,7 +54,7 @@ class TestFunctionView:
     def function_view(self, app, models, schemas):
         @app.route('/bands/<int:band_id>/')
         @doc(tags=['band'])
-        @use_kwargs({'name': fields.Str(missing='queen')}, locations=('query', ))
+        @use_kwargs({'name': fields.Str(missing='queen')}, location='query')
         @marshal_with(schemas.BandSchema, description='a band')
         def get_band(band_id):
             return models.Band(name='slowdive', genre='spacerock')
@@ -98,7 +98,7 @@ class TestArgSchema:
             name = fields.Str()
 
         @app.route('/bands/<int:band_id>/')
-        @use_kwargs(ArgSchema, locations=('query', ))
+        @use_kwargs(ArgSchema, location='query')
         def get_band(**kwargs):
             return kwargs
         return get_band
@@ -132,7 +132,7 @@ class TestCallableAsArgSchema(TestArgSchema):
             return ArgSchema
 
         @app.route('/bands/<int:band_id>/')
-        @use_kwargs(schema_factory, locations=('query', ))
+        @use_kwargs(schema_factory, location='query')
         def get_band(**kwargs):
             return kwargs
         return get_band
@@ -166,7 +166,7 @@ class TestResourceView:
     def resource_view(self, app, models, schemas):
         @doc(tags=['band'])
         class BandResource(MethodResource):
-            @use_kwargs({'name': fields.Str()}, locations=('query', ))
+            @use_kwargs({'name': fields.Str()}, location='query')
             @marshal_with(schemas.BandSchema, description='a band')
             def get(self, **kwargs):
                 return models.Band('slowdive', 'shoegaze')
@@ -212,8 +212,8 @@ class TestMultipleLocations:
             address = fields.Str()
 
         @app.route('/bands/<int:band_id>/')
-        @use_kwargs(QuerySchema, locations=('query', ))
-        @use_kwargs(BodySchema, locations=('body', ))
+        @use_kwargs(QuerySchema, location='query')
+        @use_kwargs(BodySchema, location='body')
         def get_band(**kwargs):
             return kwargs
         return get_band

--- a/tests/test_openapi.py
+++ b/tests/test_openapi.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 import pytest
 from apispec import APISpec
 from apispec.ext.marshmallow import MarshmallowPlugin

--- a/tests/test_paths.py
+++ b/tests/test_paths.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 from flask_apispec.paths import rule_to_path, rule_to_params
 
 def make_rule(app, path, **kwargs):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 from flask_apispec import utils
 
 class TestAnnotations:

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -3,8 +3,7 @@
 import json
 
 from flask import make_response
-from marshmallow import fields, Schema, post_load
-from marshmallow import EXCLUDE
+from marshmallow import fields, Schema, post_load, EXCLUDE
 
 from flask_apispec.utils import Ref
 from flask_apispec.views import MethodResource

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 import json
 
 from flask import make_response

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -10,6 +10,9 @@ from flask_apispec.views import MethodResource
 from flask_apispec import doc, use_kwargs, marshal_with
 
 
+# All the following schemas are set with unknown = EXCLUDE
+# because part of a multiple schema input.
+# This way none of them will raise errors for unknown fields handled by others
 class NameSchema(Schema):
     name = fields.Str()
 


### PR DESCRIPTION
Details for this PR are reported in #178 

Basically:

- changed the `locations` parameter in `use_kwargs `to reflect changes in webargs 6.0.0+ => `locations:tuple -> location:str`

- Fixed tests to add a `location` when missing (due to default location changed in webargs, now an explicit location is required more than before)

- Dropped compatibility with python2 (removed six, conditional requirements in setup, replaced Classifiers with python_requires, removed # -*- coding: utf-8 -*-, and other small changes).

Open issue: I'm unable to make 4 tests to work, all have multiple use_kwargs. At the moment these tests are commented in test_views.py (Added a "# I'M UNABLE TO MAKE THIS WORK" comment to mark them) to let other tests on complete.





