### PR TITLE
Fix: pin max apispec version to under 4.0.0

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,15 @@
 Changelog
 ---------
 
+0.10.1 (unreleased)
+*******************
+
+Bug fixes:
+
+* Pin to apispec<4.0.0 (:issue:`202`). Thanks :user:`catalanojuan`.
+
+This is the last release to support apispec<4.
+
 0.10.0 (2020-08-27)
 *******************
 

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ REQUIRES = [
     'flask>=0.10.1',
     'marshmallow>=3.0.0',
     'webargs>=6.0.0',
-    'apispec>=1.0.0',
+    'apispec>=1.0.0,<4.0.0',
 ]
 
 


### PR DESCRIPTION
This solves #202 by pinning apispec requirement to only supported versions (under 4.0.0)