### PR TITLE
Support apispec >= 4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,8 @@ env:
 - MARSHMALLOW_VERSION="==3.0.0"
 - MARSHMALLOW_VERSION=""
 python:
-- '3.5'
 - '3.6'
+- '3.8'
 before_install:
 - travis_retry pip install codecov
 install:
@@ -21,7 +21,7 @@ jobs:
   include:
   - stage: PyPI Release
     if: tag IS present
-    python: "3.6"
+    python: "3.8"
     env: []
     # Override install, and script to no-ops
     before_install: true

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,14 @@
 Changelog
 ---------
 
+0.11.0 (unreleased)
+*******************
+
+Features:
+
+* Support apispec>=4.0.0 (:issue:`202`). Thanks :user:`kam193`.
+  *Backwards-incompatible*: apispec<4.0.0 is no longer supported.
+
 0.10.1 (2020-10-25)
 *******************
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,6 +9,10 @@ Features:
 * Support apispec>=4.0.0 (:issue:`202`). Thanks :user:`kam193`.
   *Backwards-incompatible*: apispec<4.0.0 is no longer supported.
 
+Other changes:
+
+* *Backwards-incompatible*: Drop Python 3.5 compatibility. Only Python>=3.6 is supported.
+
 0.10.1 (2020-10-25)
 *******************
 

--- a/flask_apispec/apidoc.py
+++ b/flask_apispec/apidoc.py
@@ -72,10 +72,7 @@ class Converter:
         return None
 
     def get_parameters(self, rule, view, docs, parent=None):
-        if APISPEC_VERSION_INFO[0] < 3:
-            openapi = self.marshmallow_plugin.openapi
-        else:
-            openapi = self.marshmallow_plugin.converter
+        openapi = self.marshmallow_plugin.converter
         annotation = resolve_annotations(view, 'args', parent)
         extra_params = []
         for args in annotation.options:

--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,7 @@ setup(
     license='MIT',
     zip_safe=False,
     keywords='flask marshmallow webargs apispec',
-    python_requires=">=3.5",
+    python_requires=">=3.6",
     test_suite='tests',
     project_urls={
         'Bug Reports': 'https://github.com/jmcarp/flask-apispec/issues',

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ REQUIRES = [
     'flask>=0.10.1',
     'marshmallow>=3.0.0',
     'webargs>=6.0.0',
-    'apispec>=1.0.0',
+    'apispec>=4.0.0',
 ]
 
 

--- a/tests/test_openapi.py
+++ b/tests/test_openapi.py
@@ -25,10 +25,7 @@ def spec(marshmallow_plugin):
 
 @pytest.fixture()
 def openapi(marshmallow_plugin):
-    if APISPEC_VERSION_INFO[0] < 3:
-        return marshmallow_plugin.openapi
-    else:
-        return marshmallow_plugin.converter
+    return marshmallow_plugin.converter
 
 def ref_path(spec):
     if spec.openapi_version.version[0] < 3:

--- a/tests/test_openapi.py
+++ b/tests/test_openapi.py
@@ -1,5 +1,4 @@
 import pytest
-from unittest import mock
 from apispec import APISpec
 from apispec.ext.marshmallow import MarshmallowPlugin
 from marshmallow import fields, Schema
@@ -8,7 +7,7 @@ from flask import make_response
 from flask_apispec.paths import rule_to_params
 from flask_apispec.views import MethodResource
 from flask_apispec import doc, use_kwargs, marshal_with
-from flask_apispec.apidoc import APISPEC_VERSION_INFO, Converter, ViewConverter, ResourceConverter
+from flask_apispec.apidoc import ViewConverter, ResourceConverter
 
 @pytest.fixture()
 def marshmallow_plugin():

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist=py36,py38,pypy
+envlist=py35,py36,py37,py38,py39,pypy
 [testenv]
 deps=
     -rdev-requirements.txt

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist=py27,py35,py36,pypy
+envlist=py36,py38,pypy
 [testenv]
 deps=
     -rdev-requirements.txt


### PR DESCRIPTION
This PR introduce support for compatibility-breaking apispec 4.0.0. Since some interface and argument names are changed, I decided to drop support for older apispec. Switching to apispec 4 may require some changes in code (see https://github.com/marshmallow-code/apispec/blob/dev/CHANGELOG.rst).

Behavior of `fields2parameters` is now handled directly by flask-apispec: old method no longer exists and new 'official' way, converting to `Schema`, when fields should be in `body` conflicts with flask-apispec behavior (it generates reference to named schema instead of putting just dict with definition and registers new schema every time converted, so output can contain multiple schemas; in addition, there is a problem with names for multiple auto-generated schemas).

I strongly recommend making a recovery release with apispec pined to < 4 (PR #204) for those, who would keep on it, before merging my changes.

Fix #202 