### PR TITLE
Support for Flask-httpauth #191

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -98,6 +98,11 @@ Quickstart
             plugins=[MarshmallowPlugin()],
         ),
         'APISPEC_SWAGGER_URL': '/swagger/',
+        'APISPEC_AUTH': {
+            'ENABLED': True,
+            'USERNAME': '<username>',
+            'PASSWORD': '<password>'
+        }
     })
     docs = FlaskApiSpec(app)
 

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import find_packages
 
 REQUIRES = [
     'flask>=0.10.1',
-    'Flask-HTTPAuth==4.1.0'
+    'Flask-HTTPAuth>=4.1.0'
     'marshmallow>=3.0.0',
     'webargs>=6.0.0',
     'apispec>=4.0.0',

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,9 @@ REQUIRES = [
     'marshmallow>=2.0.0; python_version>="3"',
     'webargs>=0.18.0,<6.0.0',
     'apispec>=1.0.0',
+    'Flask-HTTPAuth==4.1.0'
 ]
+
 
 def find_version(fname):
     """Attempts to find the version number in the file names fname.


### PR DESCRIPTION
Added support for Flask-httpauth 

Can enable httpauth by the below configuration
'APISPEC_AUTH': {
    'ENABLED': True,
    'USERNAME': '<username>',
    'PASSWORD': '<password>'
}