### PR TITLE
Add required argument of APISpec: openapi_version

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -95,6 +95,7 @@ Quickstart
         'APISPEC_SPEC': APISpec(
             title='pets',
             version='v1',
+            openapi_version='3.0.3',
             plugins=[MarshmallowPlugin()],
         ),
         'APISPEC_SWAGGER_URL': '/swagger/',


### PR DESCRIPTION
Before this commit, running the sample code will throw:
    TypeError: __init__() missing 1 required positional argument: 'openapi_version'