### PR TITLE
Fix Flask 2x Support

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,14 @@
 Changelog
 ---------
 
+0.11.1 (unreleased)
+*******************
+
+Bug fixes:
+
+* Fix Flask 2.x support (:issue:`229`). Thanks :user:`KyleJamesWalker` for the PR.
+
+
 0.11.0 (2020-10-25)
 *******************
 

--- a/flask_apispec/extension.py
+++ b/flask_apispec/extension.py
@@ -103,6 +103,10 @@ class FlaskApiSpec:
             except ValueError:
                 blueprint_name = None
 
+            # Skip static rules
+            if name == 'static':
+                continue
+
             try:
                 self.register(rule, blueprint=blueprint_name)
             except TypeError:


### PR DESCRIPTION
When using Flask 2x the send_static_file function is a lambda and
crashes the extraction of the rules_by_endpoint function. There is
currently a PR that has a fix but it's been stale so I'm adding this as
a possible alternate fix.

The other fix is: https://github.com/jmcarp/flask-apispec/pull/230

Closes https://github.com/jmcarp/flask-apispec/issues/229


Note the unit tests were failing before this PR, they are now working again.


If anyone wants to use this version while we wait to have it merged and released I was able to add the following to my setup.py:
```
"flask-apispec @ https://github.com/KyleJamesWalker/flask-apispec/tarball/fix-send-static-file-lambda-flask-v2#egg=flask-apispec-0.11.0"
```